### PR TITLE
Fix skip button click detection to ignore interactions with active playback overlays

### DIFF
--- a/portable_config/webmods/Utilities/navigation.js
+++ b/portable_config/webmods/Utilities/navigation.js
@@ -912,6 +912,20 @@
       document.addEventListener('click', (e) => {
         if (!window.location.hash.startsWith('#/player')) return;
 
+        // Ignore clicks that are clearly targeting an active Stremio playback overlay.
+        // The skip button is rendered by mpv as an ASS overlay beneath the web UI.
+        if (
+          e.target.closest(
+            '.menu-layer-HZFG9, .dropdown-container-T9bZ2, .menu-container-B6cqK, .dialog-container-S5c_E, .modal-backdrop, .control-bar-container-xsWA7, .search-input-IQ0ZW, .search-bar-container-asfq1, .button-container-zVLH6, .language-option-O1Yr9, .variant-option-t7_LA, .option-COcvW, .option-GcPlB',
+          )
+        ) {
+          return;
+        }
+
+        // The ASS skip overlay can only be clicked through the player area, not through
+        // other interactive DOM layers. If the click reaches a UI control, ignore it.
+        // NOTE: Do not block video-area clicks by inspecting generic top-level elements here.
+
         // Mirror skip-toast.lua update_dimensions() math (base height = 1080)
         const scale = window.innerHeight / 1080;
         const margin = 80 * scale;


### PR DESCRIPTION
Noticed a bug where the clickable skip button would appear underneath the playback UI.

The skip button is rendered by mpv as an ASS overlay beneath the web UI. Ignoring clicks that are clearly targeting an active Stremio playback overlay.