### PR TITLE
Fix Discover detail UI, scroll perf, and hover metadata (v1.5.6)

### DIFF
--- a/portable_config/webmods/Metadata/Fetchers/tmdb-fetcher.js
+++ b/portable_config/webmods/Metadata/Fetchers/tmdb-fetcher.js
@@ -85,6 +85,51 @@
   class TMDBFetcher {
     constructor() {
       this.apiBase = API_BASE;
+      this.imdbIdCache = new Map();
+    }
+
+    /**
+     * Resolve IMDb ID from TMDB ID (fast path for Discover tmdb: links)
+     */
+    async resolveImdbIdFromTmdb(tmdbId, type = "movie") {
+      if (!tmdbId) return null;
+
+      const cacheKey = `${type}:${tmdbId}`;
+      if (this.imdbIdCache.has(cacheKey)) {
+        return this.imdbIdCache.get(cacheKey);
+      }
+
+      const apiKey = this.getApiKey();
+      if (!apiKey) return null;
+
+      const fetchUtils = getFetchUtils();
+      let imdbId = null;
+
+      try {
+        if (type === "series") {
+          const url = `${this.apiBase}/tv/${tmdbId}/external_ids?api_key=${apiKey}`;
+          const result = await fetchUtils.makeRequest(url, {
+            timeout: TIMEOUT_MS,
+          });
+          imdbId = result.data?.imdb_id || null;
+        } else {
+          const url = `${this.apiBase}/movie/${tmdbId}?api_key=${apiKey}`;
+          const result = await fetchUtils.makeRequest(url, {
+            timeout: TIMEOUT_MS,
+          });
+          imdbId = result.data?.imdb_id || null;
+        }
+      } catch (error) {
+        console.warn(
+          `[TMDB Fetcher] IMDb lookup for tmdb:${tmdbId} failed:`,
+          error,
+        );
+      }
+
+      if (imdbId) {
+        this.imdbIdCache.set(cacheKey, imdbId);
+      }
+      return imdbId || null;
     }
 
     /**
@@ -160,14 +205,16 @@
      * @param {number} tmdbId - TMDB movie ID
      * @returns {Promise<Object|null>}
      */
-    async fetchMovieDetails(tmdbId) {
+    async fetchMovieDetails(tmdbId, fast = false) {
       const apiKey = this.getApiKey();
       if (!apiKey) return null;
 
       const fetchUtils = getFetchUtils();
       const userLang =
         window.MetadataModules?.preferences?.get("language") || "en";
-      const appendToResponse = "credits,images,release_dates,translations";
+      const appendToResponse = fast
+        ? "credits"
+        : "credits,images,release_dates,translations";
       const url = `${this.apiBase}/movie/${tmdbId}?api_key=${apiKey}&language=${userLang}&append_to_response=${appendToResponse}`;
 
       try {
@@ -194,14 +241,16 @@
      * @param {number} tmdbId - TMDB TV ID
      * @returns {Promise<Object|null>}
      */
-    async fetchTVDetails(tmdbId) {
+    async fetchTVDetails(tmdbId, fast = false) {
       const apiKey = this.getApiKey();
       if (!apiKey) return null;
 
       const fetchUtils = getFetchUtils();
       const userLang =
         window.MetadataModules?.preferences?.get("language") || "en";
-      const appendToResponse = "credits,content_ratings,images,translations";
+      const appendToResponse = fast
+        ? "credits"
+        : "credits,content_ratings,images,translations";
       const url = `${this.apiBase}/tv/${tmdbId}?api_key=${apiKey}&language=${userLang}&append_to_response=${appendToResponse}`;
 
       try {
@@ -268,6 +317,21 @@
       if (!tmdbId) {
         console.debug(`[TMDB Fetcher] No TMDB ID found for ${imdbId}`);
         return null;
+      }
+
+      // Priority detail pages: skip alt titles and heavy append bundles
+      if (priority) {
+        const details =
+          type === "series"
+            ? await this.fetchTVDetails(tmdbId, true)
+            : await this.fetchMovieDetails(tmdbId, true);
+
+        if (!details) return null;
+
+        details.tmdbId = tmdbId;
+        details.imdbId = imdbId;
+        console.debug(`[TMDB Fetcher] Fast fetch ${imdbId}: ${details.title}`);
+        return details;
       }
 
       // Step 2: Fetch details + alt titles in parallel
@@ -813,6 +877,9 @@
     // Convenience methods
     fetchByImdbId: (...args) => instance.fetchByImdbId(...args),
     convertToTmdbId: (...args) => instance.convertToTmdbId(...args),
+    resolveImdbIdFromTmdb: (...args) => instance.resolveImdbIdFromTmdb(...args),
+    fetchMovieDetails: (...args) => instance.fetchMovieDetails(...args),
+    fetchTVDetails: (...args) => instance.fetchTVDetails(...args),
     getImages: (...args) => instance.getImages(...args),
     isAvailable: () => instance.isAvailable(),
     validateAuthorization: () => instance.validateAuthorization(),

--- a/portable_config/webmods/Metadata/Services/dom-processor.js
+++ b/portable_config/webmods/Metadata/Services/dom-processor.js
@@ -20,8 +20,41 @@ class DOMTitleProcessor {
     this.pendingNodes = new Set();
     this.debounceTimer = null;
     this.DEBOUNCE_DELAY = 200; // ms
+    this._catalogScrollPaused = false;
+    this._scrollPauseTimer = null;
+    this._boundMarkCatalogScroll = this.markCatalogScroll.bind(this);
 
     this.start();
+  }
+
+  markCatalogScroll() {
+    const hash = window.location.hash || "";
+    if (!hash.startsWith("#/discover")) return;
+
+    this._catalogScrollPaused = true;
+    clearTimeout(this._scrollPauseTimer);
+    this._scrollPauseTimer = setTimeout(() => {
+      this._catalogScrollPaused = false;
+      if (this.pendingNodes.size > 0) {
+        this.scheduleBatchProcessing();
+      }
+    }, 220);
+  }
+
+  isDiscoverCatalogOnly() {
+    const hash = window.location.hash || "";
+    if (!hash.startsWith("#/discover")) return false;
+
+    for (const el of document.querySelectorAll(
+      ".meta-info-container-ub8AH, [class*='metadetails-container']",
+    )) {
+      if (!el.isConnected) continue;
+      const style = window.getComputedStyle(el);
+      if (style.display === "none" || style.visibility === "hidden") continue;
+      const rect = el.getBoundingClientRect();
+      if (rect.width > 2 && rect.height > 2) return false;
+    }
+    return true;
   }
 
   subscribe(callback) {
@@ -51,6 +84,12 @@ class DOMTitleProcessor {
     // Listen for route changes to optimize performance
     this.boundHandleRouteChange = this.handleRouteChange.bind(this);
     window.addEventListener("hashchange", this.boundHandleRouteChange);
+    for (const eventName of ["wheel", "touchmove"]) {
+      document.addEventListener(eventName, this._boundMarkCatalogScroll, {
+        passive: true,
+        capture: true,
+      });
+    }
     // Initial check
     this.handleRouteChange();
 
@@ -75,6 +114,15 @@ class DOMTitleProcessor {
       window.removeEventListener("hashchange", this.boundHandleRouteChange);
       this.boundHandleRouteChange = null;
     }
+    if (this._boundMarkCatalogScroll) {
+      for (const eventName of ["wheel", "touchmove"]) {
+        document.removeEventListener(eventName, this._boundMarkCatalogScroll, {
+          capture: true,
+        });
+      }
+    }
+    clearTimeout(this._scrollPauseTimer);
+    this._scrollPauseTimer = null;
 
     this.pendingNodes.clear();
     this.processing.clear();
@@ -114,6 +162,8 @@ class DOMTitleProcessor {
   }
 
   async processExistingTitles() {
+    if (this.isDiscoverCatalogOnly()) return;
+
     // Use requestIdleCallback to avoid blocking main thread during initial load
     this.runIdle(() => {
       const elements = this.findTitleElements();
@@ -256,6 +306,8 @@ class DOMTitleProcessor {
     }
 
     this.observer = new MutationObserver((mutations) => {
+      if (this.isDiscoverCatalogOnly()) return;
+
       let hasRelevantMutations = false;
 
       for (const mutation of mutations) {
@@ -294,6 +346,21 @@ class DOMTitleProcessor {
   }
 
   scheduleBatchProcessing() {
+    if (this.isDiscoverCatalogOnly()) {
+      this.pendingNodes.clear();
+      clearTimeout(this.debounceTimer);
+      this.debounceTimer = null;
+      return;
+    }
+
+    if (this._catalogScrollPaused && (window.location.hash || "").startsWith("#/discover")) {
+      clearTimeout(this.debounceTimer);
+      this.debounceTimer = setTimeout(() => {
+        this.scheduleBatchProcessing();
+      }, 220);
+      return;
+    }
+
     if (this.debounceTimer) {
       clearTimeout(this.debounceTimer);
     }
@@ -394,6 +461,12 @@ class DOMTitleProcessor {
 
   // Private DOM extraction methods
   findTargetElement(element) {
+    if (!element) return null;
+
+    const posterHost =
+      element.closest?.(".meta-item-container-Tj0Ib, [class*='meta-item-container']") ||
+      element;
+
     // Check if element itself is already a suitable target (<a> from meta-items-container)
     if (
       element.tagName === "A" &&
@@ -404,6 +477,26 @@ class DOMTitleProcessor {
       return element;
     }
 
+    // Discover/Board detail links often have href but no id attribute
+    const detailLink =
+      posterHost.closest?.('a[href*="/detail/"]') ||
+      posterHost.querySelector?.('a[href*="/detail/"]') ||
+      element.closest?.('a[href*="/detail/"]') ||
+      element.querySelector?.('a[href*="/detail/"]');
+    if (detailLink) return detailLink;
+
+    const tabItem =
+      posterHost.querySelector?.('div[tabindex], a[id]') ||
+      posterHost.closest?.("div[tabindex]");
+    if (tabItem) return tabItem;
+
+    if (
+      posterHost.querySelector?.(this.domSelectors.posterImageGeneric) ||
+      posterHost.className?.includes?.("meta-item-container")
+    ) {
+      return posterHost;
+    }
+
     // Fallback: Try catalog rows (<a id="...">)
     const linkElement = element.closest("a[id]");
     if (linkElement) return linkElement;
@@ -412,7 +505,86 @@ class DOMTitleProcessor {
     const divElement = element.closest("div[tabindex]");
     if (divElement) return divElement;
 
-    return null; // No suitable element found
+    return posterHost !== element ? posterHost : null;
+  }
+
+  inferTypeFromContext() {
+    const hash = window.location.hash || "";
+    const hashMatch = hash.match(/\/(movie|series)(?:\/|$|\?)/);
+    if (hashMatch) return hashMatch[1];
+    return null;
+  }
+
+  mergeIdFromRaw(rawId, ids) {
+    if (!rawId) return;
+    const decoded = decodeURIComponent(String(rawId).split("/")[0].split("?")[0]);
+    const parsed = this.parseId(decoded);
+    if (!parsed?.id || parsed.idSource === "unknown") return;
+    if (!ids.type && (decoded.includes("movie") || decoded.includes("series"))) {
+      const typeMatch = decoded.match(/\/(movie|series)\//);
+      if (typeMatch) ids.type = typeMatch[1];
+    }
+    ids[parsed.idSource] = parsed.id;
+  }
+
+  mergeFromHref(href, ids) {
+    if (!href) return;
+    const urlData = this.extractFromUrl(href);
+    if (urlData?.id) {
+      if (!ids.type) ids.type = urlData.type;
+      ids[urlData.idSource] = urlData.id;
+      return;
+    }
+    const imdbMatch = href.match(/tt\d{7,}/);
+    if (imdbMatch) ids.imdb = imdbMatch[0];
+  }
+
+  mergeFromPosterSrc(src, ids) {
+    if (!src) return;
+
+    const urlData = this.extractFromUrl(src);
+    if (urlData?.id) {
+      if (!ids.type) ids.type = urlData.type;
+      ids[urlData.idSource] = urlData.id;
+      return;
+    }
+
+    const posterMatch = src.match(/\/poster\/(?:small|medium|large)\/([^/?]+)/);
+    if (posterMatch) {
+      this.mergeIdFromRaw(posterMatch[1], ids);
+      return;
+    }
+
+    const metahubMatch = src.match(/metahub\.space\/(?:poster|background|logo)\/[^/]+\/([^/?]+)/);
+    if (metahubMatch) {
+      this.mergeIdFromRaw(metahubMatch[1], ids);
+      return;
+    }
+
+    const rpdbMatch = src.match(/ratingsposterdb\.com\/[^/]+\/imdb\/[^/]+\/(tt\d{7,})/);
+    if (rpdbMatch) {
+      ids.imdb = rpdbMatch[1];
+      return;
+    }
+
+    const imdbMatch = src.match(/tt\d{7,}/);
+    if (imdbMatch) ids.imdb = imdbMatch[0];
+  }
+
+  extractTitleFromRoot(root, fallback = "") {
+    if (!root) return fallback;
+    const candidates = [
+      root.getAttribute?.("title"),
+      root.querySelector?.('[class*="title-bar"] [class*="label"]')?.textContent,
+      root.querySelector?.('[class*="title-bar-container"]')?.textContent,
+      root.querySelector?.('[class*="name-label"]')?.textContent,
+      root.querySelector?.('[class*="title-label"]')?.textContent,
+    ];
+    for (const value of candidates) {
+      const text = String(value || "").trim();
+      if (text) return text;
+    }
+    return fallback;
   }
 
   extractIdsFromElement(element) {
@@ -426,40 +598,33 @@ class DOMTitleProcessor {
       type: null,
     };
 
-    // Extract from element ID
-    if (element.id) {
-      const parsed = this.parseId(element.id);
-      if (parsed && typeof parsed.id === "string") {
-        ids[parsed.idSource] = parsed.id;
-      }
-    }
+    const roots = new Set([element]);
+    const posterHost = element.closest?.(
+      ".meta-item-container-Tj0Ib, [class*='meta-item-container']",
+    );
+    if (posterHost) roots.add(posterHost);
 
-    // Extract from href
-    const href = element.getAttribute("href");
-    if (href) {
-      const urlData = this.extractFromUrl(href);
-      if (urlData && typeof urlData.id === "string") {
-        ids.type = urlData.type;
-        ids[urlData.idSource] = urlData.id;
-      }
-    }
+    for (const root of roots) {
+      if (root.id) this.mergeIdFromRaw(root.id, ids);
 
-    // Extract from poster image
-    const img = element.querySelector(this.domSelectors.posterImage);
-    if (img?.src) {
-      const urlData = this.extractFromUrl(img.src);
-      if (urlData && typeof urlData.id === "string") {
-        if (!ids.type) ids.type = urlData.type;
-        ids[urlData.idSource] = urlData.id;
-      } else {
-        // Fallback for poster URLs
-        const match = img.src.match(
-          /\/poster\/(?:small|medium|large)\/(tt\d{7,})/,
+      this.mergeFromHref(root.getAttribute?.("href"), ids);
+
+      root.querySelectorAll?.('a[href*="/detail/"], a[href*="imdb.com/title/"]').forEach((link) => {
+        this.mergeFromHref(
+          decodeURIComponent(link.getAttribute("href") || link.href || ""),
+          ids,
         );
-        if (match && typeof match[1] === "string") {
-          ids.imdb = match[1];
-        }
-      }
+      });
+
+      root.querySelectorAll?.(
+        `${this.domSelectors.posterImage}, ${this.domSelectors.posterImageGeneric}, img[src*="metahub"], img[src*="poster"]`,
+      ).forEach((img) => {
+        this.mergeFromPosterSrc(img.getAttribute("src") || img.src, ids);
+      });
+    }
+
+    if (!ids.type) {
+      ids.type = this.inferTypeFromContext() || "movie";
     }
 
     return ids;
@@ -480,14 +645,26 @@ class DOMTitleProcessor {
 
   extractMediaInfo(titleText, element) {
     const targetElement = this.findTargetElement(element);
+    const root = targetElement || element;
+    const title =
+      titleText ||
+      this.extractTitleFromRoot(root, "") ||
+      this.extractTitleFromRoot(element, "");
+
     if (!targetElement) {
-      return this.createEmptyResult(titleText, element);
+      const ids = this.extractIdsFromElement(element);
+      const hasValidIds =
+        ids.imdb || ids.mal || ids.anilist || ids.kitsu || ids.tvdb || ids.tmdb;
+      if (!hasValidIds) {
+        return this.createEmptyResult(title, element);
+      }
+      return { ...ids, title };
     }
 
     const ids = this.extractIdsFromElement(targetElement);
     return {
       ...ids,
-      title: titleText || element.getAttribute("title") || "",
+      title,
     };
   }
 

--- a/portable_config/webmods/Metadata/Services/metadata-storage.js
+++ b/portable_config/webmods/Metadata/Services/metadata-storage.js
@@ -441,7 +441,8 @@ class MetadataStorage {
               new CustomEvent("metadata-updated", {
                 detail: {
                   imdb: storageData.imdb,
-                  id: storageData.imdb, // Compatible with different listeners
+                  id: storageData.imdb || storageData.tmdb,
+                  tmdb: storageData.tmdb,
                   type: storageData.type,
                   source: "storage",
                 },
@@ -671,7 +672,8 @@ class MetadataStorage {
             new CustomEvent("metadata-updated", {
               detail: {
                 imdb: existing.imdb,
-                id: existing.imdb,
+                id: existing.imdb || existing.tmdb,
+                tmdb: existing.tmdb,
                 type: existing.type,
                 source: "enrichment",
               },
@@ -1071,6 +1073,53 @@ class MetadataStorage {
     }
 
     // 2. If no existing entry found, proceed with standard resolution (which might include title search)
+
+    // Discover links often use tmdb: IDs — resolve via TMDB API (fast) before slow title search
+    if (!currentEntry.imdb && extractedIds.tmdb) {
+      const tmdbFetcher = window.MetadataModules?.tmdbFetcher;
+      if (tmdbFetcher?.resolveImdbIdFromTmdb) {
+        try {
+          const imdbFromTmdb = await tmdbFetcher.resolveImdbIdFromTmdb(
+            extractedIds.tmdb,
+            extractedType || currentEntry.type || "movie",
+          );
+
+          if (imdbFromTmdb) {
+            const existingByImdb = await this.getTitle(imdbFromTmdb);
+
+            if (existingByImdb) {
+              if (
+                currentEntry.id &&
+                currentEntry.id !== existingByImdb.id
+              ) {
+                await this.db.titles.delete(currentEntry.id);
+              }
+
+              const mergedEntry = this._mergeEntryData(existingByImdb, {
+                ...extractedIds,
+                imdb: imdbFromTmdb,
+                tmdb: extractedIds.tmdb,
+              });
+              await this.db.titles.put(mergedEntry);
+              return mergedEntry;
+            }
+
+            const updatedEntry = {
+              ...currentEntry,
+              imdb: imdbFromTmdb,
+              tmdb: extractedIds.tmdb,
+              type: extractedType || currentEntry.type,
+              lastUpdated: Date.now(),
+            };
+            await this.db.titles.put(updatedEntry);
+            return updatedEntry;
+          }
+        } catch (err) {
+          console.warn("[METADATA] TMDB→IMDb resolution failed:", err);
+        }
+      }
+    }
+
     const resolvedEntry = await this.idLookup.tryResolveImdbId(
       currentEntry,
       extractedIds,
@@ -1117,8 +1166,9 @@ class MetadataStorage {
       }
     }
 
-    // Skip if already complete
-    if (finalEntry.metaSource === "complete") {
+    // Skip if already complete AND has cast data for the detail UI
+    const hasCast = !!(finalEntry.stars?.length || finalEntry.directors?.length);
+    if (finalEntry.metaSource === "complete" && hasCast) {
       return finalEntry;
     }
 

--- a/portable_config/webmods/Metadata/main.js
+++ b/portable_config/webmods/Metadata/main.js
@@ -62,10 +62,11 @@ class MetadataManager {
         // 1. Initialize Core (Once)
         if (!this.core) {
             this.core = new PersistentCore();
+            // Expose storage/fetcher immediately — detail pages must not wait for catalog grid
+            this.exposeCoreAPI();
         }
 
-        // 2. Initialize UI (Transient)
-        // We wait for the app to be fully loaded (routes container) to avoid attaching observers too early
+        // 2. Initialize UI (Transient) — hover/dom observers need catalog OR detail shell
         this.waitForApp().then(() => {
             this.startUI();
         });
@@ -86,136 +87,201 @@ class MetadataManager {
         }
     }
 
+    isNonCatalogRoute() {
+        const hash = window.location.hash || "";
+        return (
+            hash.startsWith("#/detail") ||
+            hash.startsWith("#/player") ||
+            hash.startsWith("#/meta") ||
+            hash.includes("/settings") ||
+            hash.includes("/addons")
+        );
+    }
+
+    hasDetailShell() {
+        return !!document.querySelector(
+            ".meta-info-container-ub8AH, [class*='metadetails-container'], .meta-details-container",
+        );
+    }
+
     waitForApp() {
         return new Promise((resolve) => {
-            // Wait for any of the catalog containers defined in config
-            // This ensures we only start the UI when there is actual content to process
-            const selectors = window.MetadataModules.config.METADATA_CONFIG.domSelectors.containers;
-            
-            if (document.querySelector(selectors)) {
-                console.log('[METADATA] Catalog container detected, starting UI...');
+            const selectors =
+                window.MetadataModules.config.METADATA_CONFIG.domSelectors.containers;
+
+            if (
+                document.querySelector(selectors) ||
+                this.isNonCatalogRoute() ||
+                this.hasDetailShell()
+            ) {
+                console.log("[METADATA] App shell ready, starting UI...");
                 return resolve();
             }
 
-            console.log('[METADATA] Waiting for catalog containers...');
-            const observer = new MutationObserver((mutations, obs) => {
-                if (document.querySelector(selectors)) {
-                    console.log('[METADATA] Catalog container detected!');
-                    obs.disconnect();
-                    resolve();
+            console.log("[METADATA] Waiting for catalog or detail shell...");
+            let settled = false;
+            const finish = (reason) => {
+                if (settled) return;
+                settled = true;
+                observer.disconnect();
+                console.log(`[METADATA] Starting UI (${reason})`);
+                resolve();
+            };
+
+            const observer = new MutationObserver(() => {
+                if (
+                    document.querySelector(selectors) ||
+                    this.isNonCatalogRoute() ||
+                    this.hasDetailShell()
+                ) {
+                    finish("shell detected");
                 }
             });
 
             observer.observe(document.body || document.documentElement, {
                 childList: true,
-                subtree: true
+                subtree: true,
             });
-            
-            // Fallback timeout - increased to 15s to allow for slow network/rendering
-            // If no catalog appears (e.g. settings page), we might not want to start at all?
-            // For now, we'll log a warning and resolve to ensure services are available if needed manually
-            setTimeout(() => {
-                if (!document.querySelector(selectors)) {
-                    console.warn('[METADATA] Catalog wait timeout - starting anyway (or maybe we are on a non-catalog page)');
-                }
-                observer.disconnect();
-                resolve(); 
-            }, 15000);
+
+            // Short fallback — detail pages never had catalog grids (old 15s caused Discover slowness)
+            setTimeout(() => finish("timeout fallback"), 1500);
         });
     }
 
-    exposeGlobalAPI() {
-        if (typeof window === 'undefined') return;
+    exposeCoreAPI() {
+        if (typeof window === "undefined" || !this.core) return;
 
-        const { metadataStorage, idLookup, metadataFetcher, idConverter, rateLimiter, titleSearcher } = this.core;
-        const { domProcessor } = this.ui;
+        const {
+            metadataStorage,
+            idLookup,
+            metadataFetcher,
+            idConverter,
+            rateLimiter,
+            titleSearcher,
+        } = this.core;
+        const manager = this;
 
-        // Debugging & Stats
-        window.metadataStats = () => metadataStorage.getStats().then(stats => {
-            console.log('[METADATA] Stats:', stats);
-            return stats;
-        });
-        window.metadataClear = () => metadataStorage.clear();
-
-    // Expose storage for manual operations
+        window.metadataStats =
+            window.metadataStats ||
+            (() =>
+                metadataStorage.getStats().then((stats) => {
+                    console.log("[METADATA] Stats:", stats);
+                    return stats;
+                }));
+        window.metadataClear =
+            window.metadataClear || (() => metadataStorage.clear());
         window.metadataStorage = metadataStorage;
-
-    // Expose services for debugging and testing
         window.metadataServices = {
             idConverter,
             rateLimiter,
             metadataFetcher,
             titleSearcher,
-            idLookup
+            idLookup,
         };
-
-        // External API
-        window.extractMediaInfo = (titleText, element) => domProcessor.extractMediaInfo(titleText, element);
         window.getTitle = (imdbId) => metadataStorage.getTitle(imdbId);
 
-    // Expose DOM processing functions for metadata-display plugin
         window.metadataHelper = {
-            // Lifecycle
-            destroy: () => this.stopUI(), // Allow manual cleanup
-
-            // Core DOM processing
-            processTitleElement: (element) => domProcessor.processTitleElement(element),
-            findTitleElements: () => domProcessor.findTitleElements(),
-            extractMediaInfo: (titleText, element) => domProcessor.extractMediaInfo(titleText, element),
-            findTitleElementsInNode: (node) => domProcessor.findTitleElementsInNode(node),
-            isTitleElement: (element) => domProcessor.isTitleElement(element),
-
-            // Storage
+            destroy: () => manager.stopUI(),
             getTitle: (imdbId) => metadataStorage.getTitle(imdbId),
             hasTitle: (imdbId) => metadataStorage.hasTitle(imdbId),
-
-        // Database access for advanced queries
             db: metadataStorage.db,
-
-        // Cross-referencing for hover popups and external scripts
             findExistingTitle: (extractedIds, extractedTitle, extractedType) =>
-                idLookup.findExistingTitle(extractedIds, extractedTitle, extractedType),
-
-        // Priority enrichment for hover popups - accepts any ID type
-            priorityEnrichTitle: async (anyId, idSource, type, progressCallback) => {
+                idLookup.findExistingTitle(
+                    extractedIds,
+                    extractedTitle,
+                    extractedType,
+                ),
+            priorityEnrichTitle: async (
+                anyId,
+                idSource,
+                type,
+                progressCallback,
+            ) => {
                 try {
-                // Use the full cross-referencing system to find the correct entry
-                    const existingData = await idLookup.findByAnyId(anyId, idSource);
-                    if (!existingData) {
-                        console.warn(`[METADATA][Priority Enrichment] No existing data found for ${idSource}:${anyId}`);
-                        return null;
-                    }
+                    const existingData = await idLookup.findByAnyId(
+                        anyId,
+                        idSource,
+                    );
+                    if (!existingData) return null;
 
-                // Use priority enrichment with progress callbacks
-                    const enrichedData = await metadataFetcher.enrichTitleProgressively(existingData.imdb, type, existingData.metaSource, existingData, true);
+                    const enrichedData =
+                        await metadataFetcher.enrichTitleProgressively(
+                            existingData.imdb,
+                            type,
+                            existingData.metaSource,
+                            existingData,
+                            true,
+                        );
 
                     if (enrichedData && enrichedData !== existingData) {
-                    // Save the enriched data
                         await metadataStorage.saveTitle(enrichedData);
-
-                    // Update progress if callback provided
-                        if (progressCallback && enrichedData.metaSource === 'complete') {
-                            progressCallback('Complete metadata loaded');
+                        if (
+                            progressCallback &&
+                            enrichedData.metaSource === "complete"
+                        ) {
+                            progressCallback("Complete metadata loaded");
                         }
                     }
-
                     return enrichedData;
                 } catch (error) {
-                    console.error(`[METADATA][Priority Enrichment] Failed for ${anyId}:`, error);
+                    console.error(
+                        `[METADATA][Priority Enrichment] Failed for ${anyId}:`,
+                        error,
+                    );
                     return null;
                 }
             },
-
-            // Priority processing for new elements discovered by popup
             priorityProcessElement: async (element) => {
+                const domProcessor = manager.ui?.domProcessor;
+                if (!domProcessor) return null;
                 try {
-                    return await metadataStorage.processAndSaveTitleElement(element, domProcessor, true);
+                    return await metadataStorage.processAndSaveTitleElement(
+                        element,
+                        domProcessor,
+                        true,
+                    );
                 } catch (error) {
-                    console.error(`[METADATA][Priority Process] Failed for element:`, error);
+                    console.error(
+                        `[METADATA][Priority Process] Failed for element:`,
+                        error,
+                    );
                     return null;
                 }
-            }
+            },
+            processTitleElement: (element) => {
+                const domProcessor = manager.ui?.domProcessor;
+                return domProcessor
+                    ? domProcessor.processTitleElement(element)
+                    : null;
+            },
+            findTitleElements: () =>
+                manager.ui?.domProcessor?.findTitleElements?.() || [],
+            extractMediaInfo: (titleText, element) => {
+                const domProcessor = manager.ui?.domProcessor;
+                return domProcessor
+                    ? domProcessor.extractMediaInfo(titleText, element)
+                    : null;
+            },
+            findTitleElementsInNode: (node) =>
+                manager.ui?.domProcessor?.findTitleElementsInNode?.(node) || [],
+            isTitleElement: (element) =>
+                manager.ui?.domProcessor?.isTitleElement?.(element) ?? false,
         };
+
+        if (!window.__kaiMetadataCoreReady) {
+            window.__kaiMetadataCoreReady = true;
+            window.dispatchEvent(new CustomEvent("metadata-core-ready"));
+        }
+    }
+
+    exposeGlobalAPI() {
+        if (typeof window === "undefined" || !this.core || !this.ui) return;
+
+        this.exposeCoreAPI();
+
+        const { domProcessor } = this.ui;
+        window.extractMediaInfo = (titleText, element) =>
+            domProcessor.extractMediaInfo(titleText, element);
     }
 }
 

--- a/portable_config/webmods/UI/details-enhancer.js
+++ b/portable_config/webmods/UI/details-enhancer.js
@@ -1,7 +1,7 @@
 /**
  * @name Show Page Enhancer
  * @description Enriches Stremio detail pages with metadata from the database
- * @version 1.5.1
+ * @version 1.5.6
  * @patched 2026-07-16 — DOM-first detail shell watcher (no preventDefault)
  *
  * Injects enhanced ratings, tags, awards, and cast/crew information into title detail pages
@@ -111,6 +111,15 @@
  * Changelog v1.5.1:
  * - Discover catalog scroll: disconnect DOM observers when no detail shell visible
  * - Clear pinned route on catalog grid; remove viewport prefetch scan on scroll
+ *
+ * Changelog v1.5.2:
+ * - Discover scroll perf II: remove IntersectionObserver viewport prefetch entirely
+ * - Stop inject retry loops on catalog-only; boot-time route cleanup
+ * - Prefetch deferred via requestIdleCallback when not user-initiated
+ *
+ * Changelog v1.5.3:
+ * - Restore Discover catalog prefetch (IntersectionObserver) when scroll is idle
+ * - Hover/mouseover immediate warm — metadata popups work again without scroll jank
  */
 
 (function () {
@@ -122,11 +131,12 @@
   // Expose control object for debugging and cleanup
   window.ShowPageEnhancer = {
     initialized: true,
+    version: "1.5.6",
     cleanup: null, // Will be set after init
   };
 
   console.log(
-    "%c[Show Page Enhancer] v1.5.1 loaded (Discover scroll perf)",
+    "%c[Show Page Enhancer] v1.5.6 loaded (hover cinemeta fix)",
     "color: #7b5bf5; font-weight: bold",
   );
 
@@ -1252,6 +1262,7 @@
       this._prefetchCache = new Map();
       this._discoverCatalogObserved = new WeakSet();
       this.discoverCatalogObserver = null;
+      this._discoverScanTimer = null;
       this.lastSeasonParam = null;
       this.lastDiscoverDetailId = null;
       this._activeRouteKey = "";
@@ -1322,6 +1333,7 @@
       window.ShowPageEnhancer.cleanup = () => this.cleanup();
 
       this.flushPendingRoute();
+      this.handleRouteChange();
     }
 
     setupMetadataDeps() {
@@ -1361,6 +1373,13 @@
       if (this._detailWatchdogTimer) {
         clearInterval(this._detailWatchdogTimer);
         this._detailWatchdogTimer = null;
+      }
+    }
+
+    stopInjectionRetryTimer() {
+      if (this._injectionRetryTimer) {
+        clearInterval(this._injectionRetryTimer);
+        this._injectionRetryTimer = null;
       }
     }
 
@@ -1448,12 +1467,13 @@
       if (this.episodeInjector) this.episodeInjector.disconnect(); // Clean up episodes
       if (this.debounceTimer) clearTimeout(this.debounceTimer);
       if (this._processRouteTimer) clearTimeout(this._processRouteTimer);
-      if (this._injectionRetryTimer) clearInterval(this._injectionRetryTimer);
+      this.stopInjectionRetryTimer();
       this.stopDetailWatchdog();
       this.stopPersistentInjectLoop();
       this.disconnectDetailShellWatcher();
       if (this._detailShellWatcher) this._detailShellWatcher.disconnect();
       if (this.discoverCatalogObserver) this.discoverCatalogObserver.disconnect();
+      if (this._discoverScanTimer) clearTimeout(this._discoverScanTimer);
       this.currentMetadata = null;
       this.lastInjectedId = null;
       MetadataInjector.clearInjectedContent();
@@ -1522,9 +1542,13 @@
     }
 
     setupDiscoverCatalogObserver() {
+      if (this.discoverCatalogObserver) return;
+
       this.discoverCatalogObserver = new IntersectionObserver(
         (entries) => {
           if (!window.location.hash.startsWith("#/discover")) return;
+          if (!RouteDetector.isDiscoverCatalogOnly()) return;
+          if (window.KaiScrollGate?.isActive()) return;
 
           for (const entry of entries) {
             if (!entry.isIntersecting) continue;
@@ -1535,18 +1559,41 @@
 
             const routeInfo = this.parseRouteFromClickTarget(item);
             if (routeInfo) {
-              this.prefetchFromRoute(routeInfo, routeInfo.element);
+              this.prefetchFromRoute(routeInfo, routeInfo.element, {
+                immediate: true,
+              });
             }
             this.discoverCatalogObserver.unobserve(item);
           }
         },
-        { rootMargin: "250px" },
+        { rootMargin: "200px" },
       );
+    }
+
+    scheduleDiscoverCatalogScan() {
+      if (this._discoverScanTimer) return;
+
+      const tick = () => {
+        if (window.KaiScrollGate?.isActive()) {
+          this._discoverScanTimer = setTimeout(tick, 150);
+          return;
+        }
+        this._discoverScanTimer = null;
+        this.scanDiscoverCatalogItems();
+      };
+
+      this._discoverScanTimer = setTimeout(tick, 150);
     }
 
     scanDiscoverCatalogItems() {
       if (!this.discoverCatalogObserver) return;
       if (!window.location.hash.startsWith("#/discover")) return;
+      if (!RouteDetector.isDiscoverCatalogOnly()) return;
+
+      if (window.KaiScrollGate?.isActive()) {
+        this.scheduleDiscoverCatalogScan();
+        return;
+      }
 
       document.querySelectorAll(".meta-item-container-Tj0Ib").forEach((item) => {
         if (!this._discoverCatalogObserved.has(item)) {
@@ -1658,10 +1705,6 @@
           );
           if (episodesList) {
             this.episodeInjector.handleEpisodesMutation(episodesList);
-          }
-
-          if (window.location.hash.startsWith("#/discover")) {
-            this.scanDiscoverCatalogItems();
           }
         } catch (err) {
           console.error("[Show Page Enhancer] Error in MutationObserver:", err);
@@ -1775,6 +1818,7 @@
         this.disconnectDetailShellWatcher();
         this.stopDetailWatchdog();
         this.stopPersistentInjectLoop();
+        this.stopInjectionRetryTimer();
         this.isProcessing = false;
         return;
       }
@@ -1787,6 +1831,10 @@
         this.disconnectDetailShellWatcher();
         this.stopDetailWatchdog();
         this.stopPersistentInjectLoop();
+        this.stopInjectionRetryTimer();
+        this.isProcessing = false;
+        this.setupDiscoverCatalogObserver();
+        this.scanDiscoverCatalogItems();
         this.setContainerState(true);
         return;
       }
@@ -1797,6 +1845,8 @@
         this.disconnectDetailShellWatcher();
         this.stopDetailWatchdog();
         this.stopPersistentInjectLoop();
+        this.stopInjectionRetryTimer();
+        this.isProcessing = false;
         this.setContainerState(true);
         return;
       }
@@ -2096,7 +2146,22 @@
       return metadata;
     }
 
-    prefetchFromRoute(routeInfo, element = null) {
+    prefetchFromRoute(routeInfo, element = null, options = {}) {
+      if (!routeInfo?.type || !routeInfo?.id) return;
+
+      const run = () => this._prefetchFromRouteImpl(routeInfo, element);
+      if (options.immediate || element) {
+        run();
+        return;
+      }
+      if (typeof requestIdleCallback === "function") {
+        requestIdleCallback(run, { timeout: 2500 });
+      } else {
+        setTimeout(run, 0);
+      }
+    }
+
+    _prefetchFromRouteImpl(routeInfo, element = null) {
       if (!routeInfo?.type || !routeInfo?.id) return;
 
       const key = this.getRouteKey(routeInfo);
@@ -2332,18 +2397,17 @@
     }
 
     scheduleInjectionAttempts(maxAttempts = 25, intervalMs = 200) {
-      if (this._injectionRetryTimer) {
-        clearInterval(this._injectionRetryTimer);
-        this._injectionRetryTimer = null;
-      }
+      this.stopInjectionRetryTimer();
 
       let attempts = 0;
       this._injectionRetryTimer = setInterval(() => {
         attempts += 1;
 
-        if (!RouteDetector.isDetailContext()) {
-          clearInterval(this._injectionRetryTimer);
-          this._injectionRetryTimer = null;
+        if (
+          !RouteDetector.isDetailContext() ||
+          RouteDetector.isDiscoverCatalogOnly()
+        ) {
+          this.stopInjectionRetryTimer();
           return;
         }
 
@@ -2354,8 +2418,7 @@
 
         const injected = container?.classList.contains(CONFIG.MARKER_CLASS);
         if (injected || attempts >= maxAttempts) {
-          clearInterval(this._injectionRetryTimer);
-          this._injectionRetryTimer = null;
+          this.stopInjectionRetryTimer();
         }
       }, intervalMs);
     }
@@ -2381,7 +2444,7 @@
 
       if (this.isMetadataComplete(metadata)) {
         this.applyMetadataAndInject(this.normalizePeopleForUI(metadata));
-        showKaiToast("Kai v1.5.0 — metadata spremna", "ok");
+        showKaiToast("Kai v1.5.6 — metadata spremna", "ok");
         return;
       }
 
@@ -2417,7 +2480,7 @@
 
           if (this.hasDetailPageFields(metadata)) {
             this.applyMetadataAndInject(this.normalizePeopleForUI(metadata));
-            showKaiToast("Kai v1.5.0 — prikaz spreman", "ok");
+            showKaiToast("Kai v1.5.6 — prikaz spreman", "ok");
           }
         }
       } catch (e) {
@@ -2443,7 +2506,7 @@
           });
 
           if (this.isMetadataComplete(resolved)) {
-            showKaiToast("Kai v1.5.0 — metadata spremna", "ok");
+            showKaiToast("Kai v1.5.6 — metadata spremna", "ok");
           }
         })
         .catch((e) => {
@@ -2538,7 +2601,7 @@
       );
       this.lastInjectedId = routeInfo.id;
       RouteDetector.clearPinnedRoute();
-      showKaiToast("Kai v1.5.0 — prikaz detalja ucitan", "ok");
+      showKaiToast("Kai v1.5.6 — prikaz detalja ucitan", "ok");
 
       this.setContainerState(true);
     }
@@ -2588,6 +2651,14 @@
       return;
     }
     enhancer.handleRouteChange();
+  });
+
+  window.addEventListener("kai-scroll-idle", () => {
+    const enhancer = getEnhancer();
+    if (!enhancer._ready) return;
+    if (RouteDetector.isDiscoverCatalogOnly()) {
+      enhancer.scanDiscoverCatalogItems();
+    }
   });
 
   window.addEventListener("metadata-core-ready", () => {

--- a/portable_config/webmods/UI/details-enhancer.js
+++ b/portable_config/webmods/UI/details-enhancer.js
@@ -1,7 +1,7 @@
 /**
  * @name Show Page Enhancer
  * @description Enriches Stremio detail pages with metadata from the database
- * @version 1.5.0
+ * @version 1.5.1
  * @patched 2026-07-16 — DOM-first detail shell watcher (no preventDefault)
  *
  * Injects enhanced ratings, tags, awards, and cast/crew information into title detail pages
@@ -107,6 +107,10 @@
  * - Inject into visible meta container only (Discover had hidden duplicate DOM)
  * - Persistent inject loop until spe-injected marker appears
  * - navigation sets #/detail/ hash once detail DOM is visible (matches Ctrl+F5 route)
+ *
+ * Changelog v1.5.1:
+ * - Discover catalog scroll: disconnect DOM observers when no detail shell visible
+ * - Clear pinned route on catalog grid; remove viewport prefetch scan on scroll
  */
 
 (function () {
@@ -122,7 +126,7 @@
   };
 
   console.log(
-    "%c[Show Page Enhancer] v1.5.0 loaded (visible container + hash fix)",
+    "%c[Show Page Enhancer] v1.5.1 loaded (Discover scroll perf)",
     "color: #7b5bf5; font-weight: bold",
   );
 
@@ -220,6 +224,20 @@
     }
 
     return document.querySelector(CONFIG.META_CONTAINER);
+  }
+
+  /** Fast check — no getBoundingClientRect (used during catalog scroll). */
+  function hasVisibleDetailShell() {
+    for (const el of document.querySelectorAll(
+      `${CONFIG.META_CONTAINER}, [class*="metadetails-container"]`,
+    )) {
+      if (!el.isConnected) continue;
+      const style = window.getComputedStyle(el);
+      if (style.display === "none" || style.visibility === "hidden") continue;
+      const rect = el.getBoundingClientRect();
+      if (rect.width > 2 && rect.height > 2) return true;
+    }
+    return false;
   }
 
   /**
@@ -430,11 +448,19 @@
     }
 
     static isDetailContext() {
-      return (
-        RouteDetector.isDetailPage() ||
-        RouteDetector.hasDetailShell() ||
-        !!RouteDetector.getPinnedRoute()?.id
-      );
+      if (RouteDetector.isDetailPage()) return true;
+      if (hasVisibleDetailShell()) return true;
+      const pinned = RouteDetector.getPinnedRoute();
+      if (pinned?.id && (window.location.hash || "").startsWith("#/detail")) {
+        return true;
+      }
+      return false;
+    }
+
+    static isDiscoverCatalogOnly() {
+      const hash = window.location.hash || "";
+      if (!hash.startsWith("#/discover")) return false;
+      return !hasVisibleDetailShell();
     }
 
     static extractFromDOM() {
@@ -1268,9 +1294,8 @@
 
       this.setupIntersectionObserver();
       this.setupMutationObserver();
-      this.connectMutationObserver();
       this.setupDiscoverCatalogObserver();
-      this.setupDetailShellWatcher();
+      // Observers connect only on detail pages (see handleRouteChange)
 
       this._shellReady = true;
       this._ready = true;
@@ -1290,6 +1315,8 @@
         if (parsed?.id) RouteDetector.pinRoute(parsed);
         RouteDetector.invalidateCache();
         this.markPendingRoute();
+        this.connectDetailShellWatcher();
+        this.connectMutationObserver();
         this.processRoute(true);
       };
       window.ShowPageEnhancer.cleanup = () => this.cleanup();
@@ -1337,11 +1364,13 @@
       }
     }
 
-    setupDetailShellWatcher() {
+    connectDetailShellWatcher() {
       if (this._detailShellWatcher) return;
 
       this._detailShellWatcher = new MutationObserver(
         debounce(() => {
+          if (RouteDetector.isDiscoverCatalogOnly()) return;
+
           const container = getMetaContainer();
           if (!container || container.classList.contains(CONFIG.MARKER_CLASS)) {
             return;
@@ -1351,13 +1380,24 @@
 
           this.connectMutationObserver();
           this.processRoute();
-        }, 200),
+        }, 350),
       );
 
       this._detailShellWatcher.observe(document.documentElement, {
         childList: true,
         subtree: true,
       });
+    }
+
+    disconnectDetailShellWatcher() {
+      if (this._detailShellWatcher) {
+        this._detailShellWatcher.disconnect();
+        this._detailShellWatcher = null;
+      }
+    }
+
+    setupDetailShellWatcher() {
+      this.connectDetailShellWatcher();
     }
 
     startDetailWatchdog() {
@@ -1411,6 +1451,7 @@
       if (this._injectionRetryTimer) clearInterval(this._injectionRetryTimer);
       this.stopDetailWatchdog();
       this.stopPersistentInjectLoop();
+      this.disconnectDetailShellWatcher();
       if (this._detailShellWatcher) this._detailShellWatcher.disconnect();
       if (this.discoverCatalogObserver) this.discoverCatalogObserver.disconnect();
       this.currentMetadata = null;
@@ -1731,27 +1772,42 @@
         RouteDetector.clearPinnedRoute();
         this.setContainerState(false);
         this.disconnectMutationObserver();
+        this.disconnectDetailShellWatcher();
         this.stopDetailWatchdog();
+        this.stopPersistentInjectLoop();
         this.isProcessing = false;
         return;
       }
 
-      // Ensure observer is connected on detail pages
+      const inDetail = RouteDetector.isDetailContext();
+
+      if (RouteDetector.isDiscoverCatalogOnly()) {
+        RouteDetector.clearPinnedRoute();
+        this.disconnectMutationObserver();
+        this.disconnectDetailShellWatcher();
+        this.stopDetailWatchdog();
+        this.stopPersistentInjectLoop();
+        this.setContainerState(true);
+        return;
+      }
+
+      if (!inDetail) {
+        RouteDetector.clearPinnedRoute();
+        this.disconnectMutationObserver();
+        this.disconnectDetailShellWatcher();
+        this.stopDetailWatchdog();
+        this.stopPersistentInjectLoop();
+        this.setContainerState(true);
+        return;
+      }
+
       this.connectMutationObserver();
+      this.connectDetailShellWatcher();
       this.setContainerState(true);
 
       const routeInfo = RouteDetector.resolveActiveRoute();
       this.processRoute(!!routeInfo?.id);
-
-      if (RouteDetector.isDetailContext()) {
-        this.startDetailWatchdog();
-      } else {
-        this.stopDetailWatchdog();
-      }
-
-      if (window.location.hash.startsWith("#/discover")) {
-        this.scanDiscoverCatalogItems();
-      }
+      this.startDetailWatchdog();
     }
 
     getRouteKey(routeInfo) {
@@ -2123,10 +2179,15 @@
 
       let elapsed = 0;
       this._persistentInjectTimer = setInterval(() => {
-        elapsed += 200;
-        if (elapsed > 45000) {
+        elapsed += 400;
+        if (elapsed > 20000) {
           clearInterval(this._persistentInjectTimer);
           this._persistentInjectTimer = null;
+          return;
+        }
+
+        if (RouteDetector.isDiscoverCatalogOnly()) {
+          this.stopPersistentInjectLoop();
           return;
         }
 
@@ -2143,7 +2204,7 @@
         }
 
         this.injectIfReady(container);
-      }, 200);
+      }, 400);
     }
 
     stopPersistentInjectLoop() {
@@ -2181,7 +2242,7 @@
       }
 
       if (!alreadyInjected || options.forceReinject) {
-        this.scheduleInjectionAttempts(100, 250);
+        this.scheduleInjectionAttempts(40, 300);
         this.startPersistentInjectLoop();
       }
     }

--- a/portable_config/webmods/UI/details-enhancer.js
+++ b/portable_config/webmods/UI/details-enhancer.js
@@ -1,7 +1,8 @@
 /**
  * @name Show Page Enhancer
  * @description Enriches Stremio detail pages with metadata from the database
- * @version 1.3.0
+ * @version 1.5.0
+ * @patched 2026-07-16 — DOM-first detail shell watcher (no preventDefault)
  *
  * Injects enhanced ratings, tags, awards, and cast/crew information into title detail pages
  * using route-based detection and the existing metadata system.
@@ -14,6 +15,98 @@
  * - Observer lifecycle management (disconnect on non-detail pages)
  * - Error boundary around observer callback
  * - Exposed cleanup via window.ShowPageEnhancer
+ *
+ * Changelog v1.3.1:
+ * - Fetch metadata on cache miss (Discover → Detail navigation)
+ * - Enrich incomplete cache entries on detail page load
+ * - Relax DOM readiness gate when enriched metadata is already available
+ *
+ * Changelog v1.3.2:
+ * - Force full fetch when cache has stub entries (Discover catalog scans)
+ * - Enrich even when metaSource is "complete" but cast/ratings are missing
+ * - Remove description DOM gate; retry injection until container is ready
+ * - Pull TMDB/MDBList private metadata for cast on detail page open
+ *
+ * Changelog v1.3.3:
+ * - Detect movie detail shown inside Discover tab (hash stays #/discover/...)
+ * - Extract IMDb ID from DOM when URL has no /detail/ segment
+ *
+ * Changelog v1.3.4:
+ * - Single priority fetch path (removed duplicate TMDB/Cinemeta enrichment passes)
+ * - Immediate UI inject + faster DOM retries (50ms)
+ * - Require cast photos before treating cache as "complete"
+ *
+ * Changelog v1.3.5:
+ * - Progressive inject: show Cinemeta data immediately, TMDB cast follows
+ * - Bypass slow storage pipeline on detail pages (direct API fetch)
+ * - Prefetch metadata on poster click before navigation
+ * - TMDB priority mode: credits-only fetch (no alt titles / heavy bundles)
+ *
+ * Changelog v1.3.6:
+ * - Expose prefetchDetail() for Discover → Board navigation bridge
+ * - Discover catalog clicks also parsed from meta-item containers
+ *
+ * Changelog v1.3.8:
+ * - TMDB-only Discover routes (tmdb:123) fetch via TMDB directly
+ * - processAndSaveData fallback even when metadata is null
+ * - Broader extractDetailFromDOM (metadetails, metahub, page-wide links)
+ * - Debounced processRoute; clear injection only when movie ID changes
+ * - Reduced injection retries (8×100ms) to stop F5 flicker/jumps
+ * - Map TMDB cast photo → image for UI injection
+ *
+ * Changelog v1.3.9:
+ * - Prefetch stores metadata promise (reuse on navigation, no double fetch)
+ * - Progressive inject: Cinemeta UI ~1s, TMDB cast upgrades in place
+ * - Skip slow processAndSaveData when partial metadata is already usable
+ * - saveTitle runs in background (no blocking before inject)
+ * - hashchange on detail pages skips debounce; Discover redirect uses rAF
+ *
+ * Changelog v1.4.0:
+ * - Discover prefetch uses Board pipeline (priorityProcessElement → IndexedDB)
+ * - Detail page reads cache like Board (findByAnyId → inject, no parallel API path)
+ * - mousedown prefetch on catalog items (same timing as Board hover enrichment)
+ *
+ * Changelog v1.4.1:
+ * - TMDB→IMDb via TMDB API (Discover tmdb: links no longer hit 15s title search)
+ * - Detail page enrichment non-blocking (UI updates via metadata-updated)
+ * - metadata-updated matches tmdb: routes; Discover viewport priority scan
+ *
+ * Changelog v1.4.2:
+ * - Root fix: metadata API no longer waits 15s for catalog on detail pages (main.js)
+ * - Instant UI: parallel Cinemeta+TMDB display fetch; Board enrich in background
+ *
+ * Changelog v1.4.3:
+ * - Early hashchange + metadata-modules-ready: works on first Discover click (no Ctrl+F5)
+ *
+ * Changelog v1.4.4:
+ * - Discover click forces processDetailRoute (Stremio native nav bypasses hashchange)
+ * - Mutation observer always on; longer inject retries; no PopupTemplates init gate
+ * - metadata-core-ready wakes enhancer immediately when storage is live
+ *
+ * Changelog v1.4.5:
+ * - Split init: observers/listeners run before metadata deps (no Ctrl+F5)
+ * - Detail watchdog retries inject every 500ms until Kai UI appears
+ * - navigation.js: preventDefault + force #/detail/ hash on Discover click
+ *
+ * Changelog v1.4.6:
+ * - Root fix: navigation no longer blocks Stremio click (preventDefault broke React mount)
+ * - MutationObserver triggers on detail DOM shell even when hash is still #/discover/
+ * - resolveActiveRouteInfo: match metadata via DOM-extracted ID (tmdb/imdb)
+ * - Persistent detail-shell watcher at boot (independent of hash/route cache)
+ *
+ * Changelog v1.4.7:
+ * - Pin route ID from Discover poster click (kai-detail-navigate carried ID but enhancer ignored it)
+ * - resolveActiveRoute uses pinned ID when hash=#/discover and DOM has no imdb link yet
+ *
+ * Changelog v1.4.8:
+ * - Dedupe identifyAndPrepare + processAndSaveData (fixed 300+ enrich loop)
+ * - metadata-updated upgrades inject in-place instead of clear+reprocess
+ * - force processRoute no longer stacks parallel runs for same route
+ *
+ * Changelog v1.5.0:
+ * - Inject into visible meta container only (Discover had hidden duplicate DOM)
+ * - Persistent inject loop until spe-injected marker appears
+ * - navigation sets #/detail/ hash once detail DOM is visible (matches Ctrl+F5 route)
  */
 
 (function () {
@@ -29,9 +122,33 @@
   };
 
   console.log(
-    "%c[Show Page Enhancer] Script loaded!",
+    "%c[Show Page Enhancer] v1.5.0 loaded (visible container + hash fix)",
     "color: #7b5bf5; font-weight: bold",
   );
+
+  function showKaiToast(message, type = "info") {
+    try {
+      let el = document.getElementById("kai-metadata-toast");
+      if (!el) {
+        el = document.createElement("div");
+        el.id = "kai-metadata-toast";
+        el.style.cssText =
+          "position:fixed;bottom:18px;right:18px;z-index:999999;padding:10px 14px;border-radius:8px;font:12px/1.4 Segoe UI,sans-serif;color:#fff;background:rgba(30,30,30,0.92);box-shadow:0 4px 16px rgba(0,0,0,0.35);pointer-events:none;max-width:320px;";
+        document.body.appendChild(el);
+      }
+      el.textContent = message;
+      el.style.background =
+        type === "error"
+          ? "rgba(176,48,48,0.95)"
+          : type === "ok"
+            ? "rgba(36,128,72,0.95)"
+            : "rgba(30,30,30,0.92)";
+      clearTimeout(el._kaiToastTimer);
+      el._kaiToastTimer = setTimeout(() => el.remove(), 5000);
+    } catch (_) {
+      /* ignore */
+    }
+  }
 
   // Configuration
   const CONFIG = {
@@ -69,12 +186,77 @@
     DESC_CLASS: "episode-description-spe",
   };
 
+  function isElementVisible(el) {
+    if (!el?.isConnected) return false;
+    const rect = el.getBoundingClientRect();
+    if (rect.width < 2 || rect.height < 2) return false;
+    for (let node = el; node && node !== document.body; node = node.parentElement) {
+      const style = window.getComputedStyle(node);
+      if (style.display === "none" || style.visibility === "hidden") return false;
+    }
+    return true;
+  }
+
+  /** Prefer the largest visible meta container (Discover may mount hidden duplicates). */
+  function getMetaContainer() {
+    let best = null;
+    let bestArea = 0;
+
+    for (const el of document.querySelectorAll(CONFIG.META_CONTAINER)) {
+      if (!isElementVisible(el)) continue;
+      const rect = el.getBoundingClientRect();
+      const area = rect.width * rect.height;
+      if (area > bestArea) {
+        bestArea = area;
+        best = el;
+      }
+    }
+    if (best) return best;
+
+    for (const root of document.querySelectorAll('[class*="metadetails-container"]')) {
+      if (!isElementVisible(root)) continue;
+      const inner = root.querySelector(CONFIG.META_CONTAINER);
+      return inner && isElementVisible(inner) ? inner : root;
+    }
+
+    return document.querySelector(CONFIG.META_CONTAINER);
+  }
+
   /**
    * Route detector and ID extractor with caching
    */
   class RouteDetector {
     // Route state cache (invalidated on hash change)
     static _cache = { hash: "", state: null };
+    // ID captured from Discover poster click before DOM/hash expose it
+    static _pinnedRoute = null;
+
+    static pinRoute(parsed) {
+      if (!parsed?.id) return;
+      RouteDetector._pinnedRoute = {
+        view: "DETAIL",
+        type: parsed.type || "movie",
+        id: String(parsed.id),
+        source: parsed.source || "imdb",
+        fromDiscover: true,
+        pinnedAt: Date.now(),
+      };
+      RouteDetector.invalidateCache();
+    }
+
+    static clearPinnedRoute() {
+      RouteDetector._pinnedRoute = null;
+    }
+
+    static getPinnedRoute() {
+      const pinned = RouteDetector._pinnedRoute;
+      if (!pinned?.id) return null;
+      if (Date.now() - (pinned.pinnedAt || 0) > 120000) {
+        RouteDetector._pinnedRoute = null;
+        return null;
+      }
+      return pinned;
+    }
 
     // Known Route Regular Expressions
     static ROUTES = {
@@ -85,9 +267,13 @@
 
     static getRouteState() {
       const hash = window.location.hash;
+      const domDetail = RouteDetector.extractDetailFromDOM();
+      const cacheKey = domDetail?.id
+        ? `${hash}::${domDetail.type}::${domDetail.id}`
+        : hash;
 
-      // Return cached state if hash hasn't changed
-      if (RouteDetector._cache.hash === hash && RouteDetector._cache.state) {
+      // Return cached state if route context hasn't changed
+      if (RouteDetector._cache.hash === cacheKey && RouteDetector._cache.state) {
         return RouteDetector._cache.state;
       }
 
@@ -96,7 +282,7 @@
       // 1. Player (Nuclear Cleanup Phase)
       if (RouteDetector.ROUTES.PLAYER.test(hash)) {
         state = { view: "PLAYER", id: null };
-        RouteDetector._cache = { hash, state };
+        RouteDetector._cache = { hash: cacheKey, state };
         return state;
       }
 
@@ -114,7 +300,7 @@
           source: idInfo.source,
           episodeId: decodeURIComponent(streamsMatch[3]),
         };
-        RouteDetector._cache = { hash, state };
+        RouteDetector._cache = { hash: cacheKey, state };
         return state;
       }
 
@@ -134,12 +320,38 @@
           source: idInfo.source,
           season: season,
         };
-        RouteDetector._cache = { hash, state };
+        RouteDetector._cache = { hash: cacheKey, state };
+        return state;
+      }
+
+      // 4. Discover (and similar) routes keep #/discover/... while showing detail inline
+      if (/^#\/(discover|library)\//.test(hash) && domDetail?.id) {
+        state = {
+          view: "DETAIL",
+          type: domDetail.type,
+          id: domDetail.id,
+          source: domDetail.source || "imdb",
+          fromDiscover: hash.startsWith("#/discover/"),
+        };
+        RouteDetector._cache = { hash: cacheKey, state };
+        return state;
+      }
+
+      // 5. Fallback: visible detail shell in DOM (SPA remount, Discover inline, delayed hash)
+      if (domDetail?.id && getMetaContainer()) {
+        state = {
+          view: "DETAIL",
+          type: domDetail.type,
+          id: domDetail.id,
+          source: domDetail.source || "imdb",
+          fromDiscover: /^#\/discover/.test(hash),
+        };
+        RouteDetector._cache = { hash: cacheKey, state };
         return state;
       }
 
       state = { view: "UNKNOWN", id: null };
-      RouteDetector._cache = { hash, state };
+      RouteDetector._cache = { hash: cacheKey, state };
       return state;
     }
 
@@ -152,6 +364,11 @@
 
       // Handle case where ID might still have a / or ? attached
       idString = idString.split("/")[0].split("?")[0];
+
+      // Series detail URLs: tt0086659:1 → tt0086659 (season suffix)
+      if (idString.startsWith("tt") && idString.includes(":")) {
+        idString = idString.split(":")[0];
+      }
 
       let id = idString;
       let source = "imdb";
@@ -188,6 +405,38 @@
       return RouteDetector.getRouteState();
     }
 
+    /** Route from pinned click, hash, and/or mounted detail DOM. */
+    static resolveActiveRoute() {
+      const pinned = RouteDetector.getPinnedRoute();
+      if (pinned?.id) return pinned;
+
+      const state = RouteDetector.getRouteState();
+      if (state?.id && state.view !== "UNKNOWN") return state;
+
+      const dom = RouteDetector.extractDetailFromDOM();
+      if (!dom?.id) return null;
+
+      return {
+        view: "DETAIL",
+        type: dom.type || "movie",
+        source: dom.source || "imdb",
+        id: dom.id,
+        fromDiscover: (window.location.hash || "").startsWith("#/discover"),
+      };
+    }
+
+    static hasDetailShell() {
+      return !!getMetaContainer();
+    }
+
+    static isDetailContext() {
+      return (
+        RouteDetector.isDetailPage() ||
+        RouteDetector.hasDetailShell() ||
+        !!RouteDetector.getPinnedRoute()?.id
+      );
+    }
+
     static extractFromDOM() {
       const logoImg = document.querySelector(CONFIG.LOGO_IMAGE);
       const releaseInfo = document.querySelector(CONFIG.RELEASE_INFO);
@@ -199,6 +448,105 @@
       const year = yearText.match(/\d{4}/)?.[0] || "";
 
       return title ? { title, year } : null;
+    }
+
+    static extractDetailFromDOM() {
+      const inferType = (root) =>
+        root?.querySelector(CONFIG.EPISODES_CONTAINER) ? "series" : "movie";
+
+      const tryFromRoot = (metaContainer) => {
+        if (!metaContainer) return null;
+
+        const imdbBtn = metaContainer.querySelector(
+          '.imdb-button-container-gGjxp a[href*="tt"]',
+        );
+        if (imdbBtn) {
+          const id = (imdbBtn.getAttribute("href") || "").match(/tt\d+/)?.[0];
+          if (id) {
+            return { id, type: inferType(metaContainer), source: "imdb" };
+          }
+        }
+
+        for (const link of metaContainer.querySelectorAll(
+          'a[href*="/detail/"]',
+        )) {
+          const href = decodeURIComponent(link.getAttribute("href") || "");
+          const match = href.match(/\/(movie|series)\/([^/?#]+)/);
+          if (!match) continue;
+          const idInfo = RouteDetector.parseId(match[2]);
+          if (idInfo.id) {
+            return {
+              id: idInfo.id,
+              type: match[1],
+              source: idInfo.source,
+            };
+          }
+        }
+
+        for (const link of metaContainer.querySelectorAll('a[href*="tt"]')) {
+          const id = (link.getAttribute("href") || "").match(/tt\d+/)?.[0];
+          if (id) {
+            return { id, type: inferType(metaContainer), source: "imdb" };
+          }
+        }
+
+        const logoImg = metaContainer.querySelector(CONFIG.LOGO_IMAGE);
+        if (logoImg?.src) {
+          const tt = logoImg.src.match(/tt\d{7,}/);
+          if (tt) {
+            return {
+              id: tt[0],
+              type: inferType(metaContainer),
+              source: "imdb",
+            };
+          }
+        }
+
+        return null;
+      };
+
+      const roots = [];
+      const primary = getMetaContainer();
+      if (primary) roots.push(primary);
+
+      document
+        .querySelectorAll('[class*="metadetails-container"]')
+        .forEach((el) => {
+          if (!roots.includes(el)) roots.push(el);
+        });
+
+      for (const root of roots) {
+        const found = tryFromRoot(root);
+        if (found) return found;
+      }
+
+      for (const link of document.querySelectorAll(
+        'a[href*="imdb.com/title/tt"], a[href*="/detail/"]',
+      )) {
+        const href = decodeURIComponent(link.getAttribute("href") || "");
+        const tt = href.match(/tt\d{7,}/);
+        if (tt) {
+          const detailMatch = href.match(/\/(movie|series)\//);
+          return {
+            id: tt[0],
+            type: detailMatch?.[1] || inferType(link.closest("body")),
+            source: "imdb",
+          };
+        }
+        const match = href.match(/\/(movie|series)\/([^/?#]+)/);
+        if (match) {
+          const idInfo = RouteDetector.parseId(match[2]);
+          if (idInfo.id) {
+            return {
+              id: idInfo.id,
+              type: match[1],
+              source: idInfo.source,
+            };
+          }
+        }
+      }
+
+      return null;
     }
   }
 
@@ -225,7 +573,7 @@
       });
 
       // 1c. Restore stashed text node content
-      const metaContainer = document.querySelector(CONFIG.META_CONTAINER);
+      const metaContainer = getMetaContainer();
       if (metaContainer) {
         const desc = metaContainer.querySelector(
           ".description-container-yi8iU",
@@ -254,7 +602,7 @@
     static injectMetadata(metadata, intersectionObserver) {
       if (!metadata) return;
 
-      const metaContainer = document.querySelector(CONFIG.META_CONTAINER);
+      const metaContainer = getMetaContainer();
       if (!metaContainer) {
         console.error(
           "[Show Page Enhancer] Meta container not found during injection!",
@@ -867,6 +1215,7 @@
     constructor() {
       this.hashChangeHandler = this.handleRouteChange.bind(this);
       this.clickHandler = this.handleClick.bind(this);
+      this.prefetchHandler = this.handlePrefetchMousedown.bind(this);
       this.mutationObserver = null;
       this.intersectionObserver = null;
       this.currentMetadata = null;
@@ -874,46 +1223,182 @@
       this.debounceTimer = null;
       this.lastHash = "";
       this.lastInjectedId = null;
+      this._prefetchCache = new Map();
+      this._discoverCatalogObserved = new WeakSet();
+      this.discoverCatalogObserver = null;
       this.lastSeasonParam = null;
+      this.lastDiscoverDetailId = null;
+      this._activeRouteKey = "";
+      this._processRouteTimer = null;
+      this._injectionRetryTimer = null;
+      this._detailWatchdogTimer = null;
       this._observerConnected = false; // Track observer lifecycle
+      this._shellReady = false;
+      this._metadataReady = false;
+      this._ready = false;
+      this._pendingRoute = false;
+      this._identifyInflight = new Map();
       this.episodeInjector = new EpisodeInjector();
     }
 
+    markPendingRoute() {
+      this._pendingRoute = true;
+    }
+
+    flushPendingRoute() {
+      if (!this._ready) return;
+      if (this._pendingRoute || RouteDetector.isDetailContext()) {
+        this._pendingRoute = false;
+        this.handleRouteChange();
+      }
+    }
+
     init() {
-      // Dependency check (silent retry)
-      if (
-        !window.metadataHelper ||
-        !window.PopupTemplates ||
-        !window.MetadataModules?.metadataStorage
-      ) {
-        setTimeout(() => this.init(), 500);
+      this.setupShell();
+      this.setupMetadataDeps();
+    }
+
+    setupShell() {
+      if (this._shellReady) return;
+
+      this.episodeInjector.init();
+
+      document.body.addEventListener("click", this.clickHandler);
+      document.body.addEventListener("mousedown", this.prefetchHandler, true);
+
+      this.setupIntersectionObserver();
+      this.setupMutationObserver();
+      this.connectMutationObserver();
+      this.setupDiscoverCatalogObserver();
+      this.setupDetailShellWatcher();
+
+      this._shellReady = true;
+      this._ready = true;
+
+      window.ShowPageEnhancer.prefetchDetail = (routeInfo) =>
+        this.prefetchFromRoute(routeInfo, routeInfo?.element);
+      window.ShowPageEnhancer.processDetailRoute = (parsed) => {
+        if (parsed?.id) RouteDetector.pinRoute(parsed);
+        this.markPendingRoute();
+        this.setupShell();
+        this.setupMetadataDeps();
+        if (this._ready) {
+          this.processRoute(true);
+        }
+      };
+      window.ShowPageEnhancer.onDetailShellDetected = (parsed) => {
+        if (parsed?.id) RouteDetector.pinRoute(parsed);
+        RouteDetector.invalidateCache();
+        this.markPendingRoute();
+        this.processRoute(true);
+      };
+      window.ShowPageEnhancer.cleanup = () => this.cleanup();
+
+      this.flushPendingRoute();
+    }
+
+    setupMetadataDeps() {
+      if (this._metadataReady) return;
+
+      if (!window.metadataStorage || !window.metadataServices?.idLookup) {
+        if (!this._awaitingMetadataReady) {
+          this._awaitingMetadataReady = true;
+          window.addEventListener(
+            "metadata-core-ready",
+            () => this.setupMetadataDeps(),
+            { once: true },
+          );
+          window.addEventListener(
+            "metadata-modules-ready",
+            () => this.setupMetadataDeps(),
+            { once: true },
+          );
+        }
+        setTimeout(() => this.setupMetadataDeps(), 100);
         return;
       }
 
-      // Init Episode Injector (no storage needed - uses in-memory videos array)
-      this.episodeInjector.init();
+      this.setupMetadataListener();
+      this._metadataReady = true;
+      this.flushPendingRoute();
 
-      // Setup listeners
-      window.addEventListener("hashchange", this.hashChangeHandler);
-      document.body.addEventListener("click", this.clickHandler); // Delegated click listener
-      this.setupMetadataListener(); // Listener for background updates
-
-      // Setup observers
-      this.setupIntersectionObserver();
-      this.setupMutationObserver();
-
-      // Initial check
-      if (RouteDetector.isDetailPage()) {
-        this.handleRouteChange();
+      if (RouteDetector.isDetailContext()) {
+        const container = getMetaContainer();
+        if (!container?.classList.contains(CONFIG.MARKER_CLASS)) {
+          this.processRoute(true);
+        }
       }
+    }
 
-      // Expose cleanup for debugging
-      window.ShowPageEnhancer.cleanup = () => this.cleanup();
+    stopDetailWatchdog() {
+      if (this._detailWatchdogTimer) {
+        clearInterval(this._detailWatchdogTimer);
+        this._detailWatchdogTimer = null;
+      }
+    }
+
+    setupDetailShellWatcher() {
+      if (this._detailShellWatcher) return;
+
+      this._detailShellWatcher = new MutationObserver(
+        debounce(() => {
+          const container = getMetaContainer();
+          if (!container || container.classList.contains(CONFIG.MARKER_CLASS)) {
+            return;
+          }
+          if (!RouteDetector.resolveActiveRoute()?.id) return;
+          if (this._identifyInflight.size > 0) return;
+
+          this.connectMutationObserver();
+          this.processRoute();
+        }, 200),
+      );
+
+      this._detailShellWatcher.observe(document.documentElement, {
+        childList: true,
+        subtree: true,
+      });
+    }
+
+    startDetailWatchdog() {
+      this.stopDetailWatchdog();
+
+      if (!RouteDetector.isDetailContext()) return;
+
+      const container = getMetaContainer();
+      if (container?.classList.contains(CONFIG.MARKER_CLASS)) return;
+
+      let elapsed = 0;
+      const intervalMs = 500;
+      const maxMs = 30000;
+
+      this._detailWatchdogTimer = setInterval(() => {
+        elapsed += intervalMs;
+
+        if (!RouteDetector.isDetailContext()) {
+          this.stopDetailWatchdog();
+          return;
+        }
+
+        const currentContainer = getMetaContainer();
+        if (currentContainer?.classList.contains(CONFIG.MARKER_CLASS)) {
+          this.stopDetailWatchdog();
+          return;
+        }
+
+        if (elapsed >= maxMs) {
+          this.stopDetailWatchdog();
+          return;
+        }
+
+        this.connectMutationObserver();
+        this.processRoute(true);
+      }, intervalMs);
     }
 
     cleanup() {
-      window.removeEventListener("hashchange", this.hashChangeHandler);
       document.body.removeEventListener("click", this.clickHandler);
+      document.body.removeEventListener("mousedown", this.prefetchHandler, true);
       if (this.metadataListener) {
         window.removeEventListener("metadata-updated", this.metadataListener);
         this.metadataListener = null;
@@ -922,6 +1407,12 @@
       if (this.intersectionObserver) this.intersectionObserver.disconnect();
       if (this.episodeInjector) this.episodeInjector.disconnect(); // Clean up episodes
       if (this.debounceTimer) clearTimeout(this.debounceTimer);
+      if (this._processRouteTimer) clearTimeout(this._processRouteTimer);
+      if (this._injectionRetryTimer) clearInterval(this._injectionRetryTimer);
+      this.stopDetailWatchdog();
+      this.stopPersistentInjectLoop();
+      if (this._detailShellWatcher) this._detailShellWatcher.disconnect();
+      if (this.discoverCatalogObserver) this.discoverCatalogObserver.disconnect();
       this.currentMetadata = null;
       this.lastInjectedId = null;
       MetadataInjector.clearInjectedContent();
@@ -932,48 +1423,95 @@
       window.addEventListener("metadata-updated", this.metadataListener);
     }
 
+    routeMatchesUpdate(routeInfo, detail) {
+      if (!routeInfo?.id || !detail) return false;
+
+      const routeId = String(routeInfo.id);
+      if (routeId === String(detail.id)) return true;
+      if (detail.imdb && routeId === String(detail.imdb)) return true;
+      if (detail.tmdb && routeId === String(detail.tmdb)) return true;
+
+      if (routeInfo.source === "tmdb") {
+        if (this.currentMetadata?.tmdb && routeId === String(this.currentMetadata.tmdb)) {
+          return true;
+        }
+        if (detail.imdb && this.currentMetadata?.imdb === detail.imdb) {
+          return true;
+        }
+      }
+
+      return false;
+    }
+
     handleMetadataUpdate(event) {
       // Validation
       if (!event || !event.detail) return;
-      const { id, imdb } = event.detail;
+      const detail = event.detail;
 
       // Check if we are currently viewing the updated item
-      const routeInfo = RouteDetector.extractFromHash();
+      const routeInfo = RouteDetector.resolveActiveRoute();
       if (!routeInfo || !routeInfo.id) return;
 
-      if (routeInfo.id === id || routeInfo.id === imdb) {
-        // FIX: Defer DOM mutations to next frame to avoid colliding with React's
-        // reconciler during navigation transitions. Without this, clearInjectedContent()
-        // can .remove() nodes that React is mid-unmount on, causing an uncaught
-        // removeChild NotFoundError that kills the render loop (black screen freeze).
-        requestAnimationFrame(() => {
-          // Re-validate route — user may have navigated away during the frame delay
-          const currentRoute = RouteDetector.extractFromHash();
-          if (
-            !currentRoute ||
-            (currentRoute.id !== id && currentRoute.id !== imdb)
-          )
-            return;
+      if (!this.routeMatchesUpdate(routeInfo, detail)) return;
 
-          console.log(
-            `[Show Page Enhancer] Received metadata update for active item: ${id}`,
-          );
+      requestAnimationFrame(() => {
+        const currentRoute = RouteDetector.resolveActiveRoute();
+        if (
+          !currentRoute ||
+          !this.routeMatchesUpdate(currentRoute, detail)
+        )
+          return;
 
-          // Force re-process — clear current metadata to force a fresh lookup
-          this.currentMetadata = null;
+        const container = getMetaContainer();
+        if (
+          container?.classList.contains(CONFIG.MARKER_CLASS) &&
+          this.hasDetailPageFields(this.currentMetadata)
+        ) {
+          return;
+        }
 
-          const container = document.querySelector(CONFIG.META_CONTAINER);
-          if (container) {
-            // Remove marker to allow re-injection
-            container.classList.remove(CONFIG.MARKER_CLASS);
-            // Clean up content to prevent duplication before new content arrives
-            MetadataInjector.clearInjectedContent();
-          }
-
-          // Trigger processing
-          this.processRoute(true); // force=true
+        const merged = this.mergeDetailMetadata(
+          this.currentMetadata || {},
+          detail,
+        );
+        this.applyMetadataAndInject(this.normalizePeopleForUI(merged), {
+          forceReinject: !container?.classList.contains(CONFIG.MARKER_CLASS),
         });
-      }
+      });
+    }
+
+    setupDiscoverCatalogObserver() {
+      this.discoverCatalogObserver = new IntersectionObserver(
+        (entries) => {
+          if (!window.location.hash.startsWith("#/discover")) return;
+
+          for (const entry of entries) {
+            if (!entry.isIntersecting) continue;
+
+            const item = entry.target;
+            if (this._discoverCatalogObserved.has(item)) continue;
+            this._discoverCatalogObserved.add(item);
+
+            const routeInfo = this.parseRouteFromClickTarget(item);
+            if (routeInfo) {
+              this.prefetchFromRoute(routeInfo, routeInfo.element);
+            }
+            this.discoverCatalogObserver.unobserve(item);
+          }
+        },
+        { rootMargin: "250px" },
+      );
+    }
+
+    scanDiscoverCatalogItems() {
+      if (!this.discoverCatalogObserver) return;
+      if (!window.location.hash.startsWith("#/discover")) return;
+
+      document.querySelectorAll(".meta-item-container-Tj0Ib").forEach((item) => {
+        if (!this._discoverCatalogObserved.has(item)) {
+          this.discoverCatalogObserver.observe(item);
+        }
+      });
     }
 
     setupIntersectionObserver() {
@@ -1007,7 +1545,7 @@
             document.querySelector(".player-panel-lBK74")
           );
 
-          if (!RouteDetector.isDetailPage() || isPlayer) {
+          if (!RouteDetector.isDetailContext() || isPlayer) {
             if (isPlayer) {
               // Release focus from injected buttons to prevent spacebar hijacking
               if (
@@ -1026,8 +1564,27 @@
             return;
           }
 
+          // 1b. Detail shell visible — process even if hash still #/discover/
+          const routeInfo =
+            RouteDetector.resolveActiveRoute() ||
+            RouteDetector.extractFromHash();
+          if (routeInfo?.id) {
+            if (this.clearInjectionIfMovieChanged(routeInfo)) {
+              this.processRoute(true);
+              return;
+            }
+            const container = getMetaContainer();
+            if (container?.classList.contains(CONFIG.MARKER_CLASS)) {
+              return;
+            }
+            if (container && !this.currentMetadata && !this._identifyInflight.size) {
+              this.processRoute();
+              return;
+            }
+          }
+
           // 2. Refresh injection if container is missing markers
-          const container = document.querySelector(CONFIG.META_CONTAINER);
+          const container = getMetaContainer();
           if (container && !container.classList.contains(CONFIG.MARKER_CLASS)) {
             if (this.currentMetadata) {
               this.injectIfReady(container);
@@ -1061,6 +1618,10 @@
           if (episodesList) {
             this.episodeInjector.handleEpisodesMutation(episodesList);
           }
+
+          if (window.location.hash.startsWith("#/discover")) {
+            this.scanDiscoverCatalogItems();
+          }
         } catch (err) {
           console.error("[Show Page Enhancer] Error in MutationObserver:", err);
         }
@@ -1072,7 +1633,7 @@
 
     handleClick(event) {
       // Only process clicks on the detail page
-      if (!RouteDetector.isDetailPage()) return;
+      if (!RouteDetector.isDetailContext()) return;
 
       // 1. Person Clicks (Cast/Director)
       const personItem = event.target.closest(".show-page-person-item");
@@ -1144,7 +1705,7 @@
      */
     setContainerState(isActive) {
       const targets = [
-        document.querySelector(CONFIG.META_CONTAINER),
+        getMetaContainer(),
         document.querySelector(CONFIG.EPISODES_CONTAINER),
         document.querySelector(".hero-container"),
         document.querySelector(".metadata-hover-popup"),
@@ -1167,8 +1728,10 @@
 
       // State Management: Only PLAYER view needs inert state
       if (routeState.view === "PLAYER") {
+        RouteDetector.clearPinnedRoute();
         this.setContainerState(false);
         this.disconnectMutationObserver();
+        this.stopDetailWatchdog();
         this.isProcessing = false;
         return;
       }
@@ -1177,9 +1740,67 @@
       this.connectMutationObserver();
       this.setContainerState(true);
 
-      // Trigger metadata processing directly (observer handles DOM changes)
-      // No additional debounce needed - observer is already debounced
-      this.processRoute();
+      const routeInfo = RouteDetector.resolveActiveRoute();
+      this.processRoute(!!routeInfo?.id);
+
+      if (RouteDetector.isDetailContext()) {
+        this.startDetailWatchdog();
+      } else {
+        this.stopDetailWatchdog();
+      }
+
+      if (window.location.hash.startsWith("#/discover")) {
+        this.scanDiscoverCatalogItems();
+      }
+    }
+
+    getRouteKey(routeInfo) {
+      if (!routeInfo?.id) return "";
+      return `${routeInfo.type || "?"}:${routeInfo.source || "imdb"}:${routeInfo.id}`;
+    }
+
+    shouldSkipProcessing(routeInfo) {
+      const key = this.getRouteKey(routeInfo);
+      if (!key || key !== this._activeRouteKey) return false;
+      const container = getMetaContainer();
+      return !!(
+        container?.classList.contains(CONFIG.MARKER_CLASS) &&
+        this.currentMetadata
+      );
+    }
+
+    clearInjectionIfMovieChanged(routeInfo) {
+      const key = this.getRouteKey(routeInfo);
+      if (!key || key === this._activeRouteKey) return false;
+
+      this._activeRouteKey = key;
+      this.lastDiscoverDetailId = routeInfo.id;
+      this.currentMetadata = null;
+      this.lastInjectedId = null;
+      RouteDetector.invalidateCache();
+
+      const container = getMetaContainer();
+      if (container) {
+        container.classList.remove(CONFIG.MARKER_CLASS);
+        MetadataInjector.clearInjectedContent();
+      }
+      return true;
+    }
+
+    processRoute(force = false) {
+      if (force) {
+        if (this._processRouteTimer) {
+          clearTimeout(this._processRouteTimer);
+          this._processRouteTimer = null;
+        }
+        return this._processRouteImpl(true);
+      }
+
+      if (this._processRouteTimer) clearTimeout(this._processRouteTimer);
+      this._processRouteTimer = setTimeout(() => {
+        this._processRouteTimer = null;
+        this._processRouteImpl(false);
+      }, 50);
     }
 
     connectMutationObserver() {
@@ -1201,15 +1822,30 @@
       }
     }
 
-    async processRoute(force = false) {
-      if (this.isProcessing && !force) return;
-      this.isProcessing = true;
+    async _processRouteImpl(force = false) {
+      const routeInfo = RouteDetector.resolveActiveRoute();
+      if (!routeInfo?.id) return;
 
-      const routeInfo = RouteDetector.extractFromHash();
-      if (!routeInfo || !routeInfo.id) {
-        this.isProcessing = false;
+      const routeKey = this.getRouteKey(routeInfo);
+
+      if (this._identifyInflight.has(routeKey)) {
+        if (!force) return;
+        await this._identifyInflight.get(routeKey);
+        const container = getMetaContainer();
+        if (container && this.currentMetadata) {
+          this.injectIfReady(container);
+        }
         return;
       }
+
+      if (this.isProcessing && !force) return;
+      if (!force && this.shouldSkipProcessing(routeInfo)) {
+        return;
+      }
+
+      this.isProcessing = true;
+
+      this.clearInjectionIfMovieChanged(routeInfo);
 
       // Season Check (For Series Description Updates)
       const currentSeason = routeInfo.season || null;
@@ -1241,40 +1877,522 @@
       );
 
       try {
-        await this.identifyAndPrepare(RouteDetector.getRouteState());
+        const work = this.identifyAndPrepare(
+          RouteDetector.resolveActiveRoute() ||
+            RouteDetector.getRouteState(),
+        );
+        this._identifyInflight.set(routeKey, work);
+        await work;
       } catch (err) {
         console.error("[Show Page Enhancer] Error processing route:", err);
       } finally {
+        this._identifyInflight.delete(routeKey);
         this.isProcessing = false;
       }
     }
 
-    async identifyAndPrepare(routeInfo) {
-      let metadata = null;
+    hasDetailPageFields(metadata) {
+      if (!metadata) return false;
 
-      if (
-        routeInfo &&
-        window.metadataServices &&
-        window.metadataServices.idLookup
-      ) {
-        try {
-          metadata = await window.metadataServices.idLookup.findByAnyId(
-            routeInfo.id,
-            routeInfo.source || "imdb",
-            { type: routeInfo.type },
-          );
-        } catch (e) {
-          console.warn("[Show Page Enhancer] ID Lookup failed:", e);
+      const hasPeople = !!(
+        metadata.stars?.length || metadata.directors?.length
+      );
+      const hasPlot = !!(
+        metadata.plot || metadata.overview || metadata.description
+      );
+      const hasRatings =
+        (metadata.ratings && Object.keys(metadata.ratings).length > 0) ||
+        metadata.ratingsImdb != null ||
+        metadata.ratingsMetacritic != null;
+
+      return hasPeople || (hasPlot && hasRatings);
+    }
+
+    isMetadataComplete(metadata) {
+      if (!metadata) return false;
+      if (metadata.metaSource === "complete") return true;
+      return this.hasDetailPageFields(metadata);
+    }
+
+    async lookupMetadata(routeInfo, domInfo) {
+      if (!window.metadataServices?.idLookup) return null;
+
+      try {
+        return await window.metadataServices.idLookup.findByAnyId(
+          routeInfo.id,
+          routeInfo.source || "imdb",
+          { type: routeInfo.type, title: domInfo?.title },
+        );
+      } catch (e) {
+        console.warn("[Show Page Enhancer] ID Lookup failed:", e);
+        return null;
+      }
+    }
+
+    needsCastPhotos(metadata) {
+      if (!metadata) return true;
+      const people = [
+        ...(metadata.stars || []),
+        ...(metadata.directors || []),
+      ];
+      if (people.length === 0) return true;
+      return !people.some((person) => person?.image || person?.photo);
+    }
+
+    mergeDetailMetadata(base, ...sources) {
+      const fetcher = window.metadataServices?.metadataFetcher;
+      let merged = { ...(base || {}) };
+
+      for (const source of sources) {
+        if (!source) continue;
+        if (fetcher?.smartMerge) {
+          Object.assign(merged, fetcher.smartMerge(merged, source));
+        } else {
+          Object.assign(merged, source);
         }
       }
 
-      if (metadata) {
-        this.currentMetadata = metadata;
-        const container = document.querySelector(CONFIG.META_CONTAINER);
+      return merged;
+    }
+
+    normalizePeopleForUI(metadata) {
+      if (!metadata) return metadata;
+
+      const mapPeople = (people) =>
+        (people || []).map((person) => ({
+          ...person,
+          image: person?.image || person?.photo || null,
+        }));
+
+      return {
+        ...metadata,
+        stars: mapPeople(metadata.stars),
+        directors: mapPeople(metadata.directors),
+      };
+    }
+
+    async fetchDisplayMetadataFast(routeInfo, metadata, processedData) {
+      const type =
+        routeInfo.type || metadata?.type || processedData?.extractedType;
+      if (!type) return metadata;
+
+      const fetcher = window.metadataServices?.metadataFetcher;
+      const metadataService = window.MetadataModules?.metadataService;
+      const tmdbFetcher = window.MetadataModules?.tmdbFetcher;
+
+      let imdbId =
+        this.resolveRouteImdbId(routeInfo, metadata) ||
+        metadata?.imdb ||
+        (routeInfo.source === "imdb" ? routeInfo.id : null);
+
+      if (
+        !imdbId &&
+        routeInfo.source === "tmdb" &&
+        tmdbFetcher?.resolveImdbIdFromTmdb
+      ) {
+        imdbId = await tmdbFetcher.resolveImdbIdFromTmdb(routeInfo.id, type);
+      }
+
+      if (imdbId && fetcher) {
+        const baseEntry = metadata || {
+          imdb: imdbId,
+          type,
+          title: processedData?.extractedTitle || null,
+        };
+
+        const [cinemetaData, privateData] = await Promise.all([
+          fetcher.fetchCinemetaData(imdbId, type, true),
+          metadataService?.hasPrivateApiAvailable?.()
+            ? metadataService.getEnrichedMetadata(imdbId, type, true)
+            : Promise.resolve(null),
+        ]);
+
+        return this.normalizePeopleForUI(
+          this.mergeDetailMetadata(baseEntry, cinemetaData, privateData, {
+            imdb: imdbId,
+            type,
+            tmdb: routeInfo.source === "tmdb" ? routeInfo.id : baseEntry.tmdb,
+          }),
+        );
+      }
+
+      if (routeInfo.source === "tmdb" && routeInfo.id && tmdbFetcher) {
+        const tmdbId = Number(routeInfo.id);
+        const details =
+          type === "series"
+            ? await tmdbFetcher.fetchTVDetails(tmdbId, true)
+            : await tmdbFetcher.fetchMovieDetails(tmdbId, true);
+        if (!details) return metadata;
+
+        return this.normalizePeopleForUI(
+          this.mergeDetailMetadata(
+            metadata || {
+              tmdb: tmdbId,
+              type,
+              title: details.title || processedData?.extractedTitle || null,
+            },
+            details,
+            { tmdb: tmdbId, type, metaSourcePrivate: "tmdb" },
+          ),
+        );
+      }
+
+      return metadata;
+    }
+
+    prefetchFromRoute(routeInfo, element = null) {
+      if (!routeInfo?.type || !routeInfo?.id) return;
+
+      const key = this.getRouteKey(routeInfo);
+      if (this._prefetchCache.has(key)) return;
+
+      const catalogElement = element || routeInfo.element;
+      let promise = null;
+
+      if (catalogElement && window.metadataHelper?.priorityProcessElement) {
+        console.log(
+          "[Show Page Enhancer] Board prefetch:",
+          routeInfo.source || "imdb",
+          routeInfo.id,
+        );
+        promise = window.metadataHelper.priorityProcessElement(catalogElement);
+      } else if (window.metadataStorage?.processAndSaveData) {
+        promise = window.metadataStorage.processAndSaveData(
+          this.buildProcessedDataFromRoute(routeInfo),
+          true,
+        );
+      }
+
+      if (!promise) return;
+
+      promise = promise.catch(() => null);
+      this._prefetchCache.set(key, promise);
+      promise.finally(() => {
+        setTimeout(() => {
+          if (this._prefetchCache.get(key) === promise) {
+            this._prefetchCache.delete(key);
+          }
+        }, 60000);
+      });
+    }
+
+    parseRouteFromClickTarget(target) {
+      if (!target?.closest) return null;
+
+      let link = target.closest('a[href*="/detail/"]');
+      if (!link) {
+        const posterHost = target.closest(".meta-item-container-Tj0Ib");
+        if (posterHost) {
+          link =
+            posterHost.closest('a[href*="/detail/"]') ||
+            posterHost.querySelector('a[href*="/detail/"]');
+        }
+      }
+      if (!link) return null;
+
+      const href = decodeURIComponent(link.getAttribute("href") || "");
+      const match = href.match(/\/(movie|series)\/([^/?#]+)/);
+      if (!match) return null;
+
+      const idInfo = RouteDetector.parseId(match[2]);
+      if (!idInfo?.id) return null;
+
+      return {
+        type: match[1],
+        id: idInfo.id,
+        source: idInfo.source || "imdb",
+        element: link.closest(".meta-item-container-Tj0Ib") || link,
+      };
+    }
+
+    handlePrefetchMousedown(event) {
+      const routeInfo = this.parseRouteFromClickTarget(event.target);
+      if (!routeInfo) return;
+      this.prefetchFromRoute(routeInfo, routeInfo.element);
+    }
+
+    tryInjectNow() {
+      const container = getMetaContainer();
+      if (container && this.currentMetadata) {
+        this.injectIfReady(container);
+      }
+    }
+
+    startPersistentInjectLoop() {
+      if (this._persistentInjectTimer) return;
+
+      let elapsed = 0;
+      this._persistentInjectTimer = setInterval(() => {
+        elapsed += 200;
+        if (elapsed > 45000) {
+          clearInterval(this._persistentInjectTimer);
+          this._persistentInjectTimer = null;
+          return;
+        }
+
+        if (!this.currentMetadata) return;
+
+        const container = getMetaContainer();
+        if (!container) return;
+
+        if (container.classList.contains(CONFIG.MARKER_CLASS)) {
+          clearInterval(this._persistentInjectTimer);
+          this._persistentInjectTimer = null;
+          RouteDetector.clearPinnedRoute();
+          return;
+        }
+
+        this.injectIfReady(container);
+      }, 200);
+    }
+
+    stopPersistentInjectLoop() {
+      if (this._persistentInjectTimer) {
+        clearInterval(this._persistentInjectTimer);
+        this._persistentInjectTimer = null;
+      }
+    }
+
+    applyMetadataAndInject(metadata, options = {}) {
+      if (!metadata) return;
+      this.currentMetadata = metadata;
+
+      const container = getMetaContainer();
+      const alreadyInjected =
+        container?.classList.contains(CONFIG.MARKER_CLASS) ?? false;
+      const castReady =
+        (metadata.stars?.length || metadata.directors?.length) &&
+        !this.needsCastPhotos(metadata);
+      const missingCastSection =
+        container &&
+        !container.querySelector(`.${CONFIG.CAST_SECTION_CLASS}`);
+
+      if (
+        container &&
+        alreadyInjected &&
+        (options.forceReinject || (castReady && missingCastSection))
+      ) {
+        container.classList.remove(CONFIG.MARKER_CLASS);
+        MetadataInjector.clearInjectedContent();
+      }
+
+      if (container) {
+        this.injectIfReady(container);
+      }
+
+      if (!alreadyInjected || options.forceReinject) {
+        this.scheduleInjectionAttempts(100, 250);
+        this.startPersistentInjectLoop();
+      }
+    }
+
+    resolveRouteImdbId(routeInfo, metadata = null) {
+      if (metadata?.imdb?.startsWith("tt")) return metadata.imdb;
+      if (routeInfo?.source === "imdb" && routeInfo?.id?.startsWith("tt")) {
+        return routeInfo.id;
+      }
+      return null;
+    }
+
+    buildProcessedDataFromRoute(routeInfo) {
+      const domInfo = RouteDetector.extractFromDOM();
+      const idSource = routeInfo.source || "imdb";
+      const extractedIds = {
+        imdb: null,
+        tmdb: null,
+        tvdb: null,
+        mal: null,
+        anilist: null,
+        kitsu: null,
+      };
+      extractedIds[idSource] = String(routeInfo.id);
+
+      return {
+        extractedIds,
+        extractedTitle: domInfo?.title || null,
+        extractedType: routeInfo.type,
+        year: domInfo?.year || null,
+      };
+    }
+
+    async enrichMetadataIfNeeded(metadata, routeInfo, force = false) {
+      if (!metadata) return metadata;
+
+      const imdbId = this.resolveRouteImdbId(routeInfo, metadata);
+      if (!imdbId || !window.metadataServices?.metadataFetcher) return metadata;
+
+      const needsEnrichment =
+        force || !this.hasDetailPageFields(metadata) || metadata.metaSource !== "complete";
+      if (!needsEnrichment) return metadata;
+
+      try {
+        const enriched =
+          await window.metadataServices.metadataFetcher.enrichTitleProgressively(
+            imdbId,
+            metadata.type || routeInfo.type,
+            metadata.metaSource || "dom",
+            metadata,
+            true,
+          );
+
+        if (enriched && window.metadataStorage) {
+          await window.metadataStorage.saveTitle(enriched);
+          return enriched;
+        }
+      } catch (e) {
+        console.warn("[Show Page Enhancer] Enrichment failed:", e);
+      }
+
+      return metadata;
+    }
+
+    async fetchPrivateMetadata(routeInfo, metadata) {
+      const imdbId = this.resolveRouteImdbId(routeInfo, metadata);
+      const metadataService = window.MetadataModules?.metadataService;
+      if (!imdbId || !metadataService?.getEnrichedMetadata) return metadata;
+
+      try {
+        const privateData = await metadataService.getEnrichedMetadata(
+          imdbId,
+          metadata?.type || routeInfo.type,
+          true,
+        );
+        if (!privateData) return metadata;
+
+        const merged = { ...metadata, ...privateData, imdb: imdbId };
+        if (window.metadataStorage) {
+          await window.metadataStorage.saveTitle(merged);
+        }
+        return merged;
+      } catch (e) {
+        console.warn("[Show Page Enhancer] Private metadata fetch failed:", e);
+        return metadata;
+      }
+    }
+
+    scheduleInjectionAttempts(maxAttempts = 25, intervalMs = 200) {
+      if (this._injectionRetryTimer) {
+        clearInterval(this._injectionRetryTimer);
+        this._injectionRetryTimer = null;
+      }
+
+      let attempts = 0;
+      this._injectionRetryTimer = setInterval(() => {
+        attempts += 1;
+
+        if (!RouteDetector.isDetailContext()) {
+          clearInterval(this._injectionRetryTimer);
+          this._injectionRetryTimer = null;
+          return;
+        }
+
+        const container = getMetaContainer();
         if (container) {
           this.injectIfReady(container);
         }
+
+        const injected = container?.classList.contains(CONFIG.MARKER_CLASS);
+        if (injected || attempts >= maxAttempts) {
+          clearInterval(this._injectionRetryTimer);
+          this._injectionRetryTimer = null;
+        }
+      }, intervalMs);
+    }
+
+    async identifyAndPrepare(routeInfo) {
+      if (!routeInfo?.id) return;
+
+      if (!this._metadataReady) {
+        this.markPendingRoute();
+        this.setupMetadataDeps();
+        if (this.currentMetadata) {
+          const container = getMetaContainer();
+          if (container) this.injectIfReady(container);
+        }
+        return;
       }
+
+      const domInfo = RouteDetector.extractFromDOM();
+      const processedData = this.buildProcessedDataFromRoute(routeInfo);
+      const routeKey = this.getRouteKey(routeInfo);
+
+      let metadata = await this.lookupMetadata(routeInfo, domInfo);
+
+      if (this.isMetadataComplete(metadata)) {
+        this.applyMetadataAndInject(this.normalizePeopleForUI(metadata));
+        showKaiToast("Kai v1.5.0 — metadata spremna", "ok");
+        return;
+      }
+
+      showKaiToast("Kai: ucitavam metadata...", "info");
+
+      const isActiveRoute = () =>
+        this.getRouteKey(RouteDetector.resolveActiveRoute()) === routeKey;
+
+      let fullEnrichPromise = this._prefetchCache.get(routeKey);
+      if (!fullEnrichPromise && window.metadataStorage) {
+        fullEnrichPromise = window.metadataStorage
+          .processAndSaveData(processedData, true)
+          .catch(() => null);
+        this._prefetchCache.set(routeKey, fullEnrichPromise);
+      }
+
+      try {
+        console.log(
+          "[Show Page Enhancer] Fast display fetch:",
+          routeInfo.source || "imdb",
+          routeInfo.id,
+        );
+        const displayMeta = await this.fetchDisplayMetadataFast(
+          routeInfo,
+          metadata,
+          processedData,
+        );
+
+        if (displayMeta && isActiveRoute()) {
+          metadata = metadata
+            ? this.mergeDetailMetadata(metadata, displayMeta)
+            : displayMeta;
+
+          if (this.hasDetailPageFields(metadata)) {
+            this.applyMetadataAndInject(this.normalizePeopleForUI(metadata));
+            showKaiToast("Kai v1.5.0 — prikaz spreman", "ok");
+          }
+        }
+      } catch (e) {
+        console.warn("[Show Page Enhancer] Fast display fetch failed:", e);
+      }
+
+      if (!fullEnrichPromise) return;
+
+      fullEnrichPromise
+        .then(async (fresh) => {
+          if (!isActiveRoute()) return;
+
+          let resolved = fresh;
+          if (!resolved || !this.isMetadataComplete(resolved)) {
+            resolved =
+              (await this.lookupMetadata(routeInfo, domInfo)) || resolved;
+          }
+          if (!resolved) return;
+
+          this.applyMetadataAndInject(this.normalizePeopleForUI(resolved), {
+            forceReinject: true,
+            upgraded: true,
+          });
+
+          if (this.isMetadataComplete(resolved)) {
+            showKaiToast("Kai v1.5.0 — metadata spremna", "ok");
+          }
+        })
+        .catch((e) => {
+          console.warn("[Show Page Enhancer] Background enrich failed:", e);
+        })
+        .finally(() => {
+          if (this._prefetchCache.get(routeKey) === fullEnrichPromise) {
+            this._prefetchCache.delete(routeKey);
+          }
+        });
     }
 
     injectIfReady(container) {
@@ -1290,9 +2408,9 @@
       // 2. Metadata availability
       if (!this.currentMetadata) return;
 
-      // 3. ID Validation
-      const routeInfo = RouteDetector.extractFromHash();
-      if (!routeInfo) return;
+      // 3. ID Validation — use DOM-aware route (Discover tmdb: vs imdb)
+      const routeInfo = RouteDetector.resolveActiveRoute();
+      if (!routeInfo?.id) return;
 
       let isCorrectMetadata =
         this.currentMetadata.imdb === routeInfo.id ||
@@ -1309,10 +2427,17 @@
           }
         }
       }
+      if (!isCorrectMetadata && routeInfo.source === "tmdb" && this.currentMetadata?.tmdb) {
+        isCorrectMetadata =
+          String(this.currentMetadata.tmdb) === String(routeInfo.id);
+      }
+      if (!isCorrectMetadata && routeInfo.source === "imdb" && this.currentMetadata?.imdb) {
+        isCorrectMetadata =
+          String(this.currentMetadata.imdb) === String(routeInfo.id);
+      }
       if (!isCorrectMetadata) return;
 
       // 4. Update Episode Context (ALWAYS run this, even if already injected)
-      // This ensures season changes update descriptions without needing full re-injection
       if (this.episodeInjector) {
         this.episodeInjector.updateContext(this.currentMetadata);
       }
@@ -1322,33 +2447,22 @@
         return;
       }
 
-      // 6. DOM Readiness Gate — wait until key elements have rendered.
-      // Logo/placeholder: needed for correct insertion anchor.
-      // Description with content: reliable signal that the container is fully
-      // rendered. Avoids injecting before React has finished populating children,
-      // which caused the IMDb button (and logo) to appear after our rows.
+      // 6. DOM Readiness — logo, placeholder, or any native detail anchor
       const logoReady = !!container.querySelector(CONFIG.LOGO_IMAGE);
       const logoPlaceholderReady = !!container.querySelector(
         ".logo-placeholder-rE1ld",
       );
-      if (!logoReady && !logoPlaceholderReady) {
-        // Logo not present yet — DOM not stable, let observer retry
+      const hasNativeAnchor = !!(
+        container.querySelector(CONFIG.RELEASE_INFO) ||
+        container.querySelector(CONFIG.RUNTIME_LABEL) ||
+        container.querySelector(".description-container-yi8iU") ||
+        container.querySelector('[class*="logo"]')
+      );
+      if (!logoReady && !logoPlaceholderReady && !hasNativeAnchor) {
         return;
       }
 
-      // Description with text = container fully rendered.
-      // Some titles have no IMDb button at all, so we cannot use it as a
-      // readiness signal — but a populated description proves the container
-      // skeleton is done.  If description text is absent we retry next mutation.
-      const descEl = container.querySelector(".description-container-yi8iU");
-      const descReady = descEl && descEl.textContent.trim().length > 0;
-      if (!descReady) {
-        // Description not populated yet — let observer retry
-        return;
-      }
-
-      // 7. Proceed with full injection (Movies, Series Detail, and now Series Streams)
-      // Container isolation via setContainerState() handles interactivity safely
+      // 7. Proceed with full injection
       const routeState = RouteDetector.getRouteState();
       const type = this.currentMetadata.type || routeState.type;
 
@@ -1362,17 +2476,73 @@
         this.intersectionObserver,
       );
       this.lastInjectedId = routeInfo.id;
+      RouteDetector.clearPinnedRoute();
+      showKaiToast("Kai v1.5.0 — prikaz detalja ucitan", "ok");
 
-      // State is managed in handleRouteChange() - this is just safety net for injection path
       this.setContainerState(true);
     }
   }
 
+  // Singleton — survives init retries; catches hashchange before deps are ready
+  let _enhancerInstance = null;
+
+  function getEnhancer() {
+    if (!_enhancerInstance) {
+      _enhancerInstance = new ShowPageEnhancer();
+    }
+    return _enhancerInstance;
+  }
+
+  function bootEnhancer() {
+    getEnhancer().init();
+  }
+
+  function wakeEnhancerFromDiscover(parsed) {
+    if (parsed?.id) RouteDetector.pinRoute(parsed);
+    const enhancer = getEnhancer();
+    enhancer.markPendingRoute();
+    bootEnhancer();
+    if (!enhancer._ready) return;
+    const key = `${parsed?.type || "movie"}:${parsed?.source || "imdb"}:${parsed?.id}`;
+    if (enhancer._identifyInflight.has(key)) {
+      enhancer.tryInjectNow();
+      return;
+    }
+    enhancer.processRoute(true);
+  }
+
+  window.ShowPageEnhancer.processDetailRoute = (parsed) => {
+    wakeEnhancerFromDiscover(parsed);
+  };
+
+  window.addEventListener("kai-detail-navigate", (e) => {
+    wakeEnhancerFromDiscover(e.detail);
+  });
+
+  window.addEventListener("hashchange", () => {
+    const enhancer = getEnhancer();
+    if (!enhancer._ready) {
+      enhancer.markPendingRoute();
+      bootEnhancer();
+      return;
+    }
+    enhancer.handleRouteChange();
+  });
+
+  window.addEventListener("metadata-core-ready", () => {
+    bootEnhancer();
+    getEnhancer().setupMetadataDeps();
+  });
+  window.addEventListener("metadata-modules-ready", () => {
+    bootEnhancer();
+    getEnhancer().setupMetadataDeps();
+  });
+  if (window.__kaiMetadataCoreReady) bootEnhancer();
+  if (window.MetadataModules?.ready) bootEnhancer();
+
   if (document.readyState === "loading") {
-    document.addEventListener("DOMContentLoaded", () =>
-      new ShowPageEnhancer().init(),
-    );
+    document.addEventListener("DOMContentLoaded", bootEnhancer);
   } else {
-    new ShowPageEnhancer().init();
+    bootEnhancer();
   }
 })();

--- a/portable_config/webmods/UI/hover-popup.js
+++ b/portable_config/webmods/UI/hover-popup.js
@@ -3,6 +3,26 @@
  * @description Interactive hover pop-up displaying detailed metadata for Stremio catalog items
  */
 
+if (!window.KaiScrollGate) {
+  let scrollActive = false;
+  let scrollTimer = null;
+  const markScrolling = () => {
+    scrollActive = true;
+    clearTimeout(scrollTimer);
+    scrollTimer = setTimeout(() => {
+      scrollActive = false;
+      window.dispatchEvent(new CustomEvent("kai-scroll-idle"));
+    }, 200);
+  };
+  for (const eventName of ["wheel", "touchmove"]) {
+    document.addEventListener(eventName, markScrolling, {
+      passive: true,
+      capture: true,
+    });
+  }
+  window.KaiScrollGate = { isActive: () => scrollActive };
+}
+
 // Configuration constants - no magic numbers
 const POPUP_CONFIG = {
   popupClass: "metadata-hover-popup",
@@ -969,7 +989,22 @@ class MetadataHoverPopupService {
     document.body.removeEventListener("focusout", this.boundFocusOut);
   }
 
+  resolveCatalogItem(container) {
+    return (
+      container.closest(".meta-item-container-Tj0Ib, [class*='meta-item-container']") ||
+      container.closest('a[href*="/detail/"], div[tabindex]') ||
+      container
+    );
+  }
+
   handleDelegatedMouseOver(event) {
+    if (
+      window.KaiScrollGate?.isActive() &&
+      (window.location.hash || "").startsWith("#/discover")
+    ) {
+      return;
+    }
+
     const container = event.target.closest(POPUP_CONFIG.containerSelector);
 
     // If not a poster container, or if we are moving internally within the same container
@@ -977,12 +1012,13 @@ class MetadataHoverPopupService {
       return;
     }
 
-    // Store the catalog item reference if not already there (lazy extraction)
-    if (!container._catalogItem) {
-      const catalogItem = container.closest("a, div[tabindex]");
-      if (catalogItem) {
-        container._catalogItem = catalogItem;
-      }
+    container._catalogItem = this.resolveCatalogItem(container);
+
+    const catalogItem = container._catalogItem;
+    if (catalogItem && window.metadataHelper?.priorityProcessElement) {
+      window.metadataHelper
+        .priorityProcessElement(catalogItem)
+        .catch(() => {});
     }
 
     this.triggerShowPopup(container);
@@ -1408,11 +1444,28 @@ class MetadataHoverPopupService {
     });
   }
 
+  hasPopupMetadata(metadata) {
+    if (!metadata) return false;
+    if (metadata.metaSource === "complete") return true;
+    return !!(
+      metadata.plot ||
+      metadata.genres?.length ||
+      metadata.ratingsImdb != null ||
+      metadata.ratings?.imdb ||
+      metadata.stars?.length ||
+      metadata.directors?.length ||
+      metadata.runtime ||
+      metadata.year
+    );
+  }
+
   // Load metadata for popup content
   async loadMetadataForPopup(container, popup) {
     try {
       // Use the stored catalog item for media info extraction
-      const catalogItem = container._catalogItem;
+      const catalogItem =
+        container._catalogItem || this.resolveCatalogItem(container);
+      container._catalogItem = catalogItem;
       if (!catalogItem) {
         PopupUtils.log(
           "error",
@@ -1450,7 +1503,7 @@ class MetadataHoverPopupService {
       );
 
       // Only show skeleton if we don't have complete metadata
-      if (!existingMetadata || existingMetadata.metaSource !== "complete") {
+      if (!existingMetadata || !this.hasPopupMetadata(existingMetadata)) {
         const basicContent = this.generateBasicPopupContent(mediaInfo);
         this.updatePopupContent(basicContent);
       }
@@ -1462,7 +1515,7 @@ class MetadataHoverPopupService {
           "Title not found in database, triggering priority processing for immediate enrichment",
         );
         const priorityData = await this.priorityProcessElement(catalogItem);
-        if (priorityData && priorityData.metaSource === "complete") {
+        if (this.hasPopupMetadata(priorityData)) {
           // Success! Show complete content
           PopupUtils.log(
             "debug",
@@ -1483,7 +1536,7 @@ class MetadataHoverPopupService {
             PopupTemplates.createNoDataState(mediaInfo.title),
           );
         }
-      } else if (existingMetadata.metaSource === "complete") {
+      } else if (this.hasPopupMetadata(existingMetadata)) {
         // Complete metadata available - show immediately
         PopupUtils.log("debug", "Complete metadata available, showing content");
 
@@ -1529,7 +1582,7 @@ class MetadataHoverPopupService {
           "Incomplete metadata found, triggering priority processing",
         );
         const priorityData = await this.priorityProcessElement(catalogItem);
-        if (priorityData && priorityData.metaSource === "complete") {
+        if (this.hasPopupMetadata(priorityData)) {
           // Success! Show complete content
           PopupUtils.log(
             "debug",

--- a/portable_config/webmods/Utilities/navigation.js
+++ b/portable_config/webmods/Utilities/navigation.js
@@ -20,8 +20,8 @@
       this.enhanceBackButton();
       this.enhanceKeyboardNavigation();
       this.enhanceFocusState();
+      this.enhanceDiscoverDetailNavigation();
       this.initGamepad();
-      this.initSkipButtonClick();
 
       // Programmatically seize Electron Window Focus after rendering.
       // `.horizontal-nav-bar-container-Y_zvK` is always mounted regardless of hero settings.
@@ -37,6 +37,162 @@
       }, 200);
 
       console.log("[Kai Navigation] Initialized");
+    },
+
+    /**
+     * Discover tab: open films on the same #/detail/ route as Board (not inline).
+     * Warms metadata cache on mousedown so the detail page loads instantly.
+     */
+    enhanceDiscoverDetailNavigation() {
+      const parseDetailFromElement = (target) => {
+        if (!target?.closest) return null;
+
+        let link = target.closest('a[href*="/detail/"]');
+        if (!link) {
+          const posterHost = target.closest(".meta-item-container-Tj0Ib");
+          if (posterHost) {
+            link =
+              posterHost.closest('a[href*="/detail/"]') ||
+              posterHost.querySelector('a[href*="/detail/"]');
+          }
+        }
+        if (!link) return null;
+
+        const href = decodeURIComponent(
+          link.getAttribute("href") || link.href || "",
+        );
+        const match = href.match(/\/(movie|series)\/([^/?#]+)/);
+        if (!match) return null;
+
+        let id = decodeURIComponent(match[2]).split("/")[0].split("?")[0];
+        let source = "imdb";
+        if (id.startsWith("tmdb:")) {
+          source = "tmdb";
+          id = id.replace("tmdb:", "");
+        } else if (id.startsWith("tvdb:")) {
+          source = "tvdb";
+          id = id.replace("tvdb:", "");
+        }
+
+        return {
+          type: match[1],
+          id,
+          source,
+          element: link,
+        };
+      };
+
+      const warmDetailCache = (parsed) => {
+        if (!parsed) return;
+
+        // Board pipeline: priorityProcessElement saves full metadata to IndexedDB
+        if (window.ShowPageEnhancer?.prefetchDetail) {
+          window.ShowPageEnhancer.prefetchDetail(parsed);
+          return;
+        }
+
+        if (window.metadataHelper?.priorityProcessElement && parsed.element) {
+          window.metadataHelper
+            .priorityProcessElement(parsed.element)
+            .catch(() => {});
+        }
+      };
+
+      const handleDiscoverItem = (target) => {
+        if (!window.location.hash.startsWith("#/discover")) return null;
+
+        const parsed = parseDetailFromElement(target);
+        if (!parsed) return null;
+
+        warmDetailCache(parsed);
+        return parsed;
+      };
+
+      document.addEventListener(
+        "mousedown",
+        (e) => {
+          handleDiscoverItem(e.target);
+        },
+        true,
+      );
+
+      const buildDetailHash = (parsed) => {
+        const rawId =
+          parsed.source === "imdb"
+            ? parsed.id
+            : `${parsed.source}:${parsed.id}`;
+        return `#/detail/${parsed.type}/${rawId}`;
+      };
+
+      const isDetailDomVisible = () => {
+        for (const el of document.querySelectorAll(
+          ".meta-info-container-ub8AH, [class*='metadetails-container']",
+        )) {
+          const rect = el.getBoundingClientRect();
+          if (rect.width > 2 && rect.height > 2) return true;
+        }
+        return false;
+      };
+
+      // Wake enhancer after Stremio's native SPA navigation mounts detail DOM.
+      // Do NOT preventDefault — blocking Stremio breaks React mount (Ctrl+F5 was the workaround).
+      const wakeDetailEnhancer = (parsed) => {
+        warmDetailCache(parsed);
+        const detailHash = buildDetailHash(parsed);
+
+        const tick = () => {
+          if (isDetailDomVisible() && window.location.hash !== detailHash) {
+            window.location.hash = detailHash;
+          }
+          window.dispatchEvent(
+            new CustomEvent("kai-detail-navigate", { detail: parsed }),
+          );
+          window.ShowPageEnhancer?.onDetailShellDetected?.(parsed);
+          window.ShowPageEnhancer?.processDetailRoute?.(parsed);
+        };
+
+        tick();
+        [100, 300, 600, 1200, 2000, 3500].forEach((ms) =>
+          setTimeout(tick, ms),
+        );
+      };
+
+      document.addEventListener(
+        "click",
+        (e) => {
+          const parsed = handleDiscoverItem(e.target);
+          if (!parsed) return;
+          wakeDetailEnhancer(parsed);
+        },
+        true,
+      );
+
+      document.addEventListener(
+        "keydown",
+        (e) => {
+          if (e.key !== "Enter") return;
+          const parsed = handleDiscoverItem(e.target);
+          if (!parsed) return;
+          wakeDetailEnhancer(parsed);
+        },
+        true,
+      );
+
+      document.addEventListener(
+        "mouseover",
+        (e) => {
+          if (!window.location.hash.startsWith("#/discover")) return;
+          const item = e.target.closest(".meta-item-container-Tj0Ib");
+          if (!item) return;
+          const parsed = parseDetailFromElement(item);
+          warmDetailCache(parsed);
+        },
+        true,
+      );
+
+      console.log(
+        "[Kai Navigation] Discover detail hash + inject (v1.5.0)",
+      );
     },
 
     /**
@@ -901,40 +1057,6 @@
         },
         { capture: true },
       );
-    },
-
-    /**
-     * Click-to-skip: detects clicks in the skip button region and forwards to mpv.
-     * The skip button is an mpv ASS overlay — clicks can't reach Lua directly, so we
-     * mirror the Lua coordinate math here and send a script-message via the WebView bridge.
-     */
-    initSkipButtonClick() {
-      document.addEventListener('click', (e) => {
-        if (!window.location.hash.startsWith('#/player')) return;
-
-        // Mirror skip-toast.lua update_dimensions() math (base height = 1080)
-        const scale = window.innerHeight / 1080;
-        const margin = 80 * scale;
-        const btnWidth = 200 * scale;
-        const btnHeight = 60 * scale;
-        const extraOffset = 80 * scale; // space above control bar
-
-        const ax = window.innerWidth - btnWidth - margin;
-        const ay = window.innerHeight - btnHeight - margin - extraOffset;
-        const bx = window.innerWidth - margin;
-        const by = window.innerHeight - margin - extraOffset;
-
-        if (e.clientX >= ax && e.clientX <= bx && e.clientY >= ay && e.clientY <= by) {
-          e.stopPropagation();
-          e.preventDefault();
-          window.chrome?.webview?.postMessage(JSON.stringify({
-            type: 6,
-            object: 'transport',
-            method: 'handleInboundJSON',
-            args: ['mpv-command', ['script-message-to', 'notify_skip', 'perform-skip']],
-          }));
-        }
-      }, { capture: true });
     },
 
     /**

--- a/portable_config/webmods/Utilities/navigation.js
+++ b/portable_config/webmods/Utilities/navigation.js
@@ -10,6 +10,35 @@
   window.KaiNavigation = window.KaiNavigation || {};
   window.KaiNavigation.initialized = true;
 
+  // Shared scroll gate — suppresses hover/prefetch work while catalog is moving
+  if (!window.KaiScrollGate) {
+    let scrollActive = false;
+    let scrollTimer = null;
+    const markScrolling = () => {
+      scrollActive = true;
+      clearTimeout(scrollTimer);
+    scrollTimer = setTimeout(() => {
+      scrollActive = false;
+      window.dispatchEvent(new CustomEvent("kai-scroll-idle"));
+    }, 200);
+    };
+    for (const eventName of ["wheel", "touchmove"]) {
+      document.addEventListener(eventName, markScrolling, {
+        passive: true,
+        capture: true,
+      });
+    }
+    window.KaiScrollGate = { isActive: () => scrollActive };
+  }
+
+  const runWhenIdle = (fn) => {
+    if (typeof requestIdleCallback === "function") {
+      requestIdleCallback(fn, { timeout: 2500 });
+    } else {
+      setTimeout(fn, 0);
+    }
+  };
+
   const CONFIG = {
     RELEASES_URL: "https://allecsc.github.io/Stremio-Kai/changelog.html",
   };
@@ -78,23 +107,33 @@
           type: match[1],
           id,
           source,
-          element: link,
+          element: link.closest(".meta-item-container-Tj0Ib") || link,
         };
       };
 
-      const warmDetailCache = (parsed) => {
+      const warmDetailCache = (parsed, options = {}) => {
         if (!parsed) return;
+        const run = () => {
+          // Board pipeline: priorityProcessElement saves full metadata to IndexedDB
+          if (window.ShowPageEnhancer?.prefetchDetail) {
+            window.ShowPageEnhancer.prefetchDetail({
+              ...parsed,
+              element: parsed.element,
+            });
+            return;
+          }
 
-        // Board pipeline: priorityProcessElement saves full metadata to IndexedDB
-        if (window.ShowPageEnhancer?.prefetchDetail) {
-          window.ShowPageEnhancer.prefetchDetail(parsed);
-          return;
-        }
+          if (window.metadataHelper?.priorityProcessElement && parsed.element) {
+            window.metadataHelper
+              .priorityProcessElement(parsed.element)
+              .catch(() => {});
+          }
+        };
 
-        if (window.metadataHelper?.priorityProcessElement && parsed.element) {
-          window.metadataHelper
-            .priorityProcessElement(parsed.element)
-            .catch(() => {});
+        if (options.immediate) {
+          run();
+        } else {
+          runWhenIdle(run);
         }
       };
 
@@ -104,7 +143,7 @@
         const parsed = parseDetailFromElement(target);
         if (!parsed) return null;
 
-        warmDetailCache(parsed);
+        warmDetailCache(parsed, { immediate: true });
         return parsed;
       };
 
@@ -137,7 +176,7 @@
       // Wake enhancer after Stremio's native SPA navigation mounts detail DOM.
       // Do NOT preventDefault — blocking Stremio breaks React mount (Ctrl+F5 was the workaround).
       const wakeDetailEnhancer = (parsed) => {
-        warmDetailCache(parsed);
+        warmDetailCache(parsed, { immediate: true });
         const detailHash = buildDetailHash(parsed);
 
         const tick = () => {
@@ -182,19 +221,20 @@
         "mouseover",
         (e) => {
           if (!window.location.hash.startsWith("#/discover")) return;
+          if (window.KaiScrollGate?.isActive()) return;
           const item = e.target.closest(".meta-item-container-Tj0Ib");
           if (!item) return;
           const now = Date.now();
           if (now - (NavigationManager._lastDiscoverWarm || 0) < 400) return;
           NavigationManager._lastDiscoverWarm = now;
           const parsed = parseDetailFromElement(item);
-          warmDetailCache(parsed);
+          warmDetailCache(parsed, { immediate: true });
         },
         true,
       );
 
       console.log(
-        "[Kai Navigation] Discover detail hash + inject (v1.5.0)",
+        "[Kai Navigation] Discover detail hash + inject (v1.5.3 prefetch restore)",
       );
     },
 

--- a/portable_config/webmods/Utilities/navigation.js
+++ b/portable_config/webmods/Utilities/navigation.js
@@ -184,6 +184,9 @@
           if (!window.location.hash.startsWith("#/discover")) return;
           const item = e.target.closest(".meta-item-container-Tj0Ib");
           if (!item) return;
+          const now = Date.now();
+          if (now - (NavigationManager._lastDiscoverWarm || 0) < 400) return;
+          NavigationManager._lastDiscoverWarm = now;
           const parsed = parseDetailFromElement(item);
           warmDetailCache(parsed);
         },


### PR DESCRIPTION
## Summary

Fixes Discover tab → film/serija not showing Kai enhanced metadata on the **first click** without hard refresh (Ctrl+F5). Also fixes Discover scroll jank and hover popup metadata on catalog posters.

Board navigation was already working.

## Root cause

1. Discover often keeps `#/discover/...` hash while showing detail inline — enhancer relied on `#/detail/` hash only
2. Discover can mount **duplicate** `.meta-info-container` nodes (one hidden by theme CSS) — inject targeted wrong/invisible DOM
3. Poster click ID was not passed to the enhancer before hash/DOM exposed the route
4. Metadata API blocked up to 15s waiting for catalog grid on detail pages
5. v1.4.5 `preventDefault` on Discover clicks broke Stremio React mount (reverted in v1.5.0)
6. Scroll jank: global observers/prefetch ran during catalog scroll (v1.5.1–v1.5.2)
7. Hover popup: Discover posters have no `/detail/` href — IDs must come from poster image URL (ratingsposterdb/metahub)
8. Hover popup rejected enriched metadata with `metaSource: "cinemeta"` because it only accepted `"complete"` (v1.5.6)

## Changes

### `UI/details-enhancer.js` (v1.5.6)
- Pin route ID from Discover poster click (`RouteDetector.pinRoute`)
- `getMetaContainer()` — inject into largest **visible** meta container
- `resolveActiveRoute()` — pinned ID → hash → DOM fallback
- Deduped enrich pipeline (no 100+ enrich loop)
- Disconnect DOM observers on Discover catalog-only view (scroll perf)
- Restore catalog prefetch via IntersectionObserver when scroll is idle
- Version exposed as `ShowPageEnhancer.version`

### `Utilities/navigation.js`
- Native Stremio click (no `preventDefault`)
- Set `#/detail/...` hash once detail DOM is visible
- `KaiScrollGate` — suppress prefetch/hover work during active scroll
- Immediate cache warm on hover/mousedown when scroll idle

### `UI/hover-popup.js`
- `resolveCatalogItem()` for Discover poster DOM structure
- Accept cinemeta/tmdb/imdb enriched metadata (not only `metaSource === "complete"`)
- Skip hover trigger during active catalog scroll

### `Metadata/Services/dom-processor.js`
- Deep ID extraction from poster URLs (ratingsposterdb, metahub, tmdb:, tt...)
- Pause batch DOM processing during Discover scroll
- Skip mutation batch on catalog-only grid (scroll perf)

### `Metadata/main.js`, `metadata-storage.js`, `tmdb-fetcher.js`
- Early metadata API exposure (no 15s catalog wait on detail)
- TMDB → IMDb fast path for Discover `tmdb:` links

## Test plan

- [ ] Board → film: Kai UI unchanged
- [ ] Discover → film **first click**: Kai UI without Ctrl+F5
- [ ] Discover scroll/search: smooth, no stutter
- [ ] Discover hover on poster: ratings, plot, cast (not "No details available")
- [ ] Console: `ShowPageEnhancer.version` → `"1.5.6"`
- [ ] No 100+ `Successfully enriched` spam in console

Reported and verified on Windows Stremio Kai portable install.
